### PR TITLE
Add ROS C++ Style Guide CLANG format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,64 @@
+---
+BasedOnStyle: Google
+AccessModifierOffset: -2
+ConstructorInitializerIndentWidth: 2
+AlignEscapedNewlinesLeft: false
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AlwaysBreakTemplateDeclarations: true
+AlwaysBreakBeforeMultilineStrings: true
+BreakBeforeBinaryOperators: false
+BreakBeforeTernaryOperators: false
+BreakConstructorInitializersBeforeComma: true
+BinPackParameters: true
+ColumnLimit: 120
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+DerivePointerBinding: false
+PointerBindsToType: true
+ExperimentalAutoDetectBinPacking: false
+IndentCaseLabels: true
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 60
+PenaltyBreakString: 1
+PenaltyBreakFirstLessLess: 1000
+PenaltyExcessCharacter: 1000
+PenaltyReturnTypeOnItsOwnLine: 90
+SpacesBeforeTrailingComments: 2
+Cpp11BracedListStyle: false
+Standard: Auto
+IndentWidth: 2
+TabWidth: 2
+UseTab: Never
+IndentFunctionDeclarationAfterType: false
+SpacesInParentheses: false
+SpacesInAngles: false
+SpaceInEmptyParentheses: false
+SpacesInCStyleCastParentheses: false
+SpaceAfterControlStatementKeyword: true
+SpaceBeforeAssignmentOperators: true
+ContinuationIndentWidth: 4
+SortIncludes: false
+SpaceAfterCStyleCast: false
+
+# Configure each individual brace in BraceWrapping
+BreakBeforeBraces: Custom
+
+# Control of individual brace wrapping cases
+BraceWrapping: {
+    AfterClass: 'true'
+    AfterControlStatement: 'true'
+    AfterEnum : 'true'
+    AfterFunction : 'true'
+    AfterNamespace : 'true'
+    AfterStruct : 'true'
+    AfterUnion : 'true'
+    BeforeCatch : 'true'
+    BeforeElse : 'true'
+    IndentBraces : 'false'
+}

--- a/include/abb_librws/common/rw/io.h
+++ b/include/abb_librws/common/rw/io.h
@@ -4,13 +4,12 @@
 #include <variant>
 #include <string>
 
-
-namespace abb :: rws :: rw :: io
+namespace abb ::rws ::rw ::io
 {
-    /**
-     * \brief Mapping from IO signal name to a value.
-     *
-     * The value of a digital signal is a \a bool, the value of an analog signal is a \a float.
-     */
-    using IOSignalInfo = std::map<std::string, std::variant<bool, float>>;
-}
+/**
+ * \brief Mapping from IO signal name to a value.
+ *
+ * The value of a digital signal is a \a bool, the value of an analog signal is a \a float.
+ */
+using IOSignalInfo = std::map<std::string, std::variant<bool, float>>;
+}  // namespace abb::rws::rw::io

--- a/include/abb_librws/common/rw/panel.h
+++ b/include/abb_librws/common/rw/panel.h
@@ -4,84 +4,81 @@
 
 #include <string>
 
-
-namespace abb :: rws :: rw
+namespace abb ::rws ::rw
 {
-    /**
-     * \brief Robot controller state.
-     *
-     * The documentation strings are taken from https://developercenter.robotstudio.com/api/RWS?urls.primaryName=Panel%20Service
-     */
-    enum class ControllerState
-    {
-        // The robot is starting up. It will shift to state motors off when it has started.
-        init,
-        // The robot is in a standby state where there is no power to the robot's motors.
-        // The state has to be shifted to motors on before the robot can move.
-        motorOff,
-        // The robot is ready to move, either by jogging or by running programs.
-        motorOn,
-        // The robot is stopped because the safety runchain is opened. For instance, a door to the robot's cell might be open.
-        guardStop,
-        // The robot is stopped because emergency stop was activated.
-        emergencyStop,
-        // The robot is ready to leave emergency stop state. The emergency stop is no longer activated, but the state transition isn't yet confirmed.
-        emergencyStopReset,
-        // The robot is in a system failure state. Restart required.
-        sysFail
-    };
+/**
+ * \brief Robot controller state.
+ *
+ * The documentation strings are taken from
+ * https://developercenter.robotstudio.com/api/RWS?urls.primaryName=Panel%20Service
+ */
+enum class ControllerState
+{
+  // The robot is starting up. It will shift to state motors off when it has started.
+  init,
+  // The robot is in a standby state where there is no power to the robot's motors.
+  // The state has to be shifted to motors on before the robot can move.
+  motorOff,
+  // The robot is ready to move, either by jogging or by running programs.
+  motorOn,
+  // The robot is stopped because the safety runchain is opened. For instance, a door to the robot's cell might be open.
+  guardStop,
+  // The robot is stopped because emergency stop was activated.
+  emergencyStop,
+  // The robot is ready to leave emergency stop state. The emergency stop is no longer activated, but the state
+  // transition isn't yet confirmed.
+  emergencyStopReset,
+  // The robot is in a system failure state. Restart required.
+  sysFail
+};
 
+std::ostream& operator<<(std::ostream& os, ControllerState state);
 
-    std::ostream& operator<<(std::ostream& os, ControllerState state);
+/**
+ * \brief Create \a ControllerState from string.
+ *
+ * \param str source string
+ *
+ * \return \a ControllerState matching the value of \a str
+ *
+ * \throw \a std::invalid_argument if \a str is not from the set of valid strings.
+ */
+ControllerState makeControllerState(std::string const& str);
 
+/**
+ * @brief Robot operation mode.
+ *
+ * The documentation strings are taken from
+ * https://developercenter.robotstudio.com/api/rwsApi/panel_opmode_get_page.html
+ */
+enum class OperationMode
+{
+  // State init
+  init,
+  // State change request for automatic mode
+  autoCh,
+  // State change request for manual mode & full speed
+  manFCh,
+  // State manual mode & reduced speed
+  manR,
+  // State manual mode & full speed
+  manF,
+  // State automatic mode
+  automatic,
+  // Undefined
+  undef
+};
 
-    /**
-     * \brief Create \a ControllerState from string.
-     *
-     * \param str source string
-     *
-     * \return \a ControllerState matching the value of \a str
-     *
-     * \throw \a std::invalid_argument if \a str is not from the set of valid strings.
-     */
-    ControllerState makeControllerState(std::string const& str);
+std::ostream& operator<<(std::ostream& os, OperationMode mode);
 
-
-    /**
-     * @brief Robot operation mode.
-     *
-     * The documentation strings are taken from https://developercenter.robotstudio.com/api/rwsApi/panel_opmode_get_page.html
-     */
-    enum class OperationMode
-    {
-        // State init
-        init,
-        // State change request for automatic mode
-        autoCh,
-        // State change request for manual mode & full speed
-        manFCh,
-        // State manual mode & reduced speed
-        manR,
-        // State manual mode & full speed
-        manF,
-        // State automatic mode
-        automatic,
-        // Undefined
-        undef
-    };
-
-
-    std::ostream& operator<<(std::ostream& os, OperationMode mode);
-
-
-    /**
-     * \brief Create \a OperationMode from string.
-     *
-     * \param str source string
-     *
-     * \return \a OperationMode matching the value of \a str
-     *
-     * \throw \a std::invalid_argument if \a str is not from the set of valid strings.
-     */
-    OperationMode makeOperationMode(std::string const& str);
-}
+/**
+ * \brief Create \a OperationMode from string.
+ *
+ * \param str source string
+ *
+ * \return \a OperationMode matching the value of \a str
+ *
+ * \throw \a std::invalid_argument if \a str is not from the set of valid strings.
+ */
+OperationMode makeOperationMode(std::string const& str);
+}  // namespace abb::rws::rw

--- a/include/abb_librws/common/rw/rapid.h
+++ b/include/abb_librws/common/rw/rapid.h
@@ -5,155 +5,139 @@
 #include <string>
 #include <iosfwd>
 
-
-namespace abb :: rws :: rw
+namespace abb ::rws ::rw
 {
-    /**
-     * \brief run mode of a RAPID program.
-     */
-    enum class RAPIDRunMode
-    {
-        forever,
-        asis,
-        once,
-        oncedone
-    };
+/**
+ * \brief run mode of a RAPID program.
+ */
+enum class RAPIDRunMode
+{
+  forever,
+  asis,
+  once,
+  oncedone
+};
 
+/**
+ * \brief Create \a RAPIDRunMode from string.
+ *
+ * \param str source string
+ *
+ * \return \a RAPIDRunMode matching the value of \a str
+ *
+ * \throw \a std::invalid_argument if \a str is not from the set of valid strings.
+ */
+RAPIDRunMode makeRAPIDRunMode(std::string const& str);
 
-    /**
-     * \brief Create \a RAPIDRunMode from string.
-     *
-     * \param str source string
-     *
-     * \return \a RAPIDRunMode matching the value of \a str
-     *
-     * \throw \a std::invalid_argument if \a str is not from the set of valid strings.
-     */
-    RAPIDRunMode makeRAPIDRunMode(std::string const& str);
+/**
+ * \brief State of RAPID program.
+ */
+enum class RAPIDExecutionState : bool
+{
+  stopped = false,
+  running = true
+};
 
+std::ostream& operator<<(std::ostream& os, RAPIDExecutionState const& state);
 
-    /**
-     * \brief State of RAPID program.
-     */
-    enum class RAPIDExecutionState : bool
-    {
-        stopped = false,
-        running = true
-    };
+/**
+ * \brief Create \a RAPIDExecutionState from string.
+ *
+ * \param str source string
+ *
+ * \return \a RAPIDExecutionState matching the value of \a str
+ *
+ * \throw \a std::invalid_argument if \a str is not from the set of valid strings.
+ */
+RAPIDExecutionState makeRAPIDExecutionState(std::string const& str);
 
+/**
+ * \brief Execution state and run mode of a RAPID program.
+ */
+struct RAPIDExecutionInfo
+{
+  /// \brief Rapid execution state
+  RAPIDExecutionState ctrlexecstate;
 
-    std::ostream& operator<<(std::ostream& os, RAPIDExecutionState const& state);
+  /// Current run mode
+  RAPIDRunMode cycle;
+};
 
+/**
+ * \brief A struct for containing information about a RAPID module.
+ */
+struct RAPIDModuleInfo
+{
+  /**
+   * \brief A constructor.
+   *
+   * \param name for the name of the module.
+   * \param type for the type of the module.
+   */
+  RAPIDModuleInfo(const std::string& name, const std::string& type) : name(name), type(type)
+  {
+  }
 
-    /**
-     * \brief Create \a RAPIDExecutionState from string.
-     *
-     * \param str source string
-     *
-     * \return \a RAPIDExecutionState matching the value of \a str
-     *
-     * \throw \a std::invalid_argument if \a str is not from the set of valid strings.
-     */
-    RAPIDExecutionState makeRAPIDExecutionState(std::string const& str);
+  /**
+   * \brief The module's name.
+   */
+  std::string name;
 
+  /**
+   * \brief The module's type.
+   */
+  std::string type;
+};
 
-    /**
-     * \brief Execution state and run mode of a RAPID program.
-     */
-    struct RAPIDExecutionInfo
-    {
-        /// \brief Rapid execution state
-        RAPIDExecutionState ctrlexecstate;
+/**
+ * \brief Execution state of a RAPID task.
+ */
+enum class RAPIDTaskExecutionState
+{
+  UNKNOWN,       ///< The task state is unknown.
+  READY,         ///< The task is ready.
+  STOPPED,       ///< The task has been stopped.
+  STARTED,       ///< The task has been started.
+  UNINITIALIZED  ///< The task has not been initialized.
+};
 
-        /// Current run mode
-        RAPIDRunMode cycle;
-    };
+/**
+ * \brief A struct for containing information about a RAPID task.
+ */
+struct RAPIDTaskInfo
+{
+  /**
+   * \brief A constructor.
+   *
+   * \param name for the name of the task.
+   * \param is_motion_task indicating if the task is a motion task or not.
+   * \param is_active indicating if the task is active or not.
+   * \param execution_state indicating the task's current execution state.
+   */
+  RAPIDTaskInfo(const std::string& name, const bool is_motion_task, const bool is_active,
+                const RAPIDTaskExecutionState execution_state)
+    : name(name), is_motion_task(is_motion_task), is_active(is_active), execution_state(execution_state)
+  {
+  }
 
+  /**
+   * \brief The task's name.
+   */
+  std::string name;
 
-    /**
-     * \brief A struct for containing information about a RAPID module.
-     */
-    struct RAPIDModuleInfo
-    {
-        /**
-         * \brief A constructor.
-         *
-         * \param name for the name of the module.
-         * \param type for the type of the module.
-         */
-        RAPIDModuleInfo(const std::string& name, const std::string& type)
-        :
-        name(name),
-        type(type)
-        {}
+  /**
+   * \brief Flag indicating if the task is a motion task.
+   */
+  bool is_motion_task;
 
-        /**
-         * \brief The module's name.
-         */
-        std::string name;
+  /**
+   * \brief Flag indicating if the task is active or not.
+   */
+  bool is_active;
 
-        /**
-         * \brief The module's type.
-         */
-        std::string type;
-    };
-
-
-    /**
-     * \brief Execution state of a RAPID task.
-     */
-    enum class RAPIDTaskExecutionState
-    {
-        UNKNOWN,      ///< The task state is unknown.
-        READY,        ///< The task is ready.
-        STOPPED,      ///< The task has been stopped.
-        STARTED,      ///< The task has been started.
-        UNINITIALIZED ///< The task has not been initialized.
-    };
-
-
-    /**
-     * \brief A struct for containing information about a RAPID task.
-     */
-    struct RAPIDTaskInfo
-    {
-        /**
-         * \brief A constructor.
-         *
-         * \param name for the name of the task.
-         * \param is_motion_task indicating if the task is a motion task or not.
-         * \param is_active indicating if the task is active or not.
-         * \param execution_state indicating the task's current execution state.
-         */
-        RAPIDTaskInfo(const std::string& name,
-                    const bool is_motion_task,
-                    const bool is_active,
-                    const RAPIDTaskExecutionState execution_state)
-        :
-        name(name),
-        is_motion_task(is_motion_task),
-        is_active(is_active),
-        execution_state(execution_state)
-        {}
-
-        /**
-         * \brief The task's name.
-         */
-        std::string name;
-
-        /**
-         * \brief Flag indicating if the task is a motion task.
-         */
-        bool is_motion_task;
-
-        /**
-         * \brief Flag indicating if the task is active or not.
-         */
-        bool is_active;
-
-        /**
-         * \brief The current execution state of the task.
-         */
-        RAPIDTaskExecutionState execution_state;
-    };
-}
+  /**
+   * \brief The current execution state of the task.
+   */
+  RAPIDTaskExecutionState execution_state;
+};
+}  // namespace abb::rws::rw

--- a/include/abb_librws/connection_options.h
+++ b/include/abb_librws/connection_options.h
@@ -5,38 +5,36 @@
 #include <string>
 #include <chrono>
 
-
-namespace abb :: rws
+namespace abb ::rws
 {
-    struct ConnectionOptions
-    {
-        ConnectionOptions(std::string const& ip_address,
-            unsigned short port = SystemConstants::General::DEFAULT_PORT_NUMBER,
-            std::string const& username = SystemConstants::General::DEFAULT_USERNAME,
-            std::string password = SystemConstants::General::DEFAULT_PASSWORD,
-            std::chrono::microseconds connection_timeout = std::chrono::milliseconds {400},
-            std::chrono::microseconds send_timeout = std::chrono::milliseconds {400},
-            std::chrono::microseconds receive_timeout = std::chrono::milliseconds {400});
+struct ConnectionOptions
+{
+  ConnectionOptions(std::string const& ip_address, unsigned short port = SystemConstants::General::DEFAULT_PORT_NUMBER,
+                    std::string const& username = SystemConstants::General::DEFAULT_USERNAME,
+                    std::string password = SystemConstants::General::DEFAULT_PASSWORD,
+                    std::chrono::microseconds connection_timeout = std::chrono::milliseconds{ 400 },
+                    std::chrono::microseconds send_timeout = std::chrono::milliseconds{ 400 },
+                    std::chrono::microseconds receive_timeout = std::chrono::milliseconds{ 400 });
 
-        /// \brief Robot controller's IP address.
-        std::string ip_address;
+  /// \brief Robot controller's IP address.
+  std::string ip_address;
 
-        /// \brief port used by the RWS server.
-        unsigned short port;
+  /// \brief port used by the RWS server.
+  unsigned short port;
 
-        /// \brief username to the RWS authentication process.
-        std::string username;
+  /// \brief username to the RWS authentication process.
+  std::string username;
 
-        /// \brief password to the RWS authentication process.
-        std::string password;
+  /// \brief password to the RWS authentication process.
+  std::string password;
 
-        /// \brief HTTP connection timeout
-        std::chrono::microseconds connection_timeout = std::chrono::milliseconds {400};
+  /// \brief HTTP connection timeout
+  std::chrono::microseconds connection_timeout = std::chrono::milliseconds{ 400 };
 
-        /// \brief HTTP send timeout
-        std::chrono::microseconds send_timeout = std::chrono::milliseconds {400};
+  /// \brief HTTP send timeout
+  std::chrono::microseconds send_timeout = std::chrono::milliseconds{ 400 };
 
-        /// \brief HTTP receive timeout
-        std::chrono::microseconds receive_timeout = std::chrono::milliseconds {400};
-    };
-}
+  /// \brief HTTP receive timeout
+  std::chrono::microseconds receive_timeout = std::chrono::milliseconds{ 400 };
+};
+}  // namespace abb::rws

--- a/include/abb_librws/rws.h
+++ b/include/abb_librws/rws.h
@@ -2,48 +2,42 @@
 
 #include <iosfwd>
 
-
-namespace abb :: rws
+namespace abb ::rws
 {
-  /// @brief Modes for stopping RAPID execution.
-  ///
-  /// https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_stop_page.html
-  ///
-  enum class StopMode
-  {
-    cycle,
-    instr,
-    stop,
-    qstop
-  };
+/// @brief Modes for stopping RAPID execution.
+///
+/// https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_stop_page.html
+///
+enum class StopMode
+{
+  cycle,
+  instr,
+  stop,
+  qstop
+};
 
+std::ostream& operator<<(std::ostream& os, StopMode stopmode);
 
-  std::ostream& operator<<(std::ostream& os, StopMode stopmode);
+/// @brief (?) Defines which tasks should be stopped.
+///
+/// https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_stop_page.html
+///
+enum class UseTsp
+{
+  normal,
+  alltsk
+};
 
+std::ostream& operator<<(std::ostream& os, UseTsp usetsp);
 
-  /// @brief (?) Defines which tasks should be stopped.
-  ///
-  /// https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_stop_page.html
-  ///
-  enum class UseTsp
-  {
-    normal,
-    alltsk
-  };
+/// @brief RWS mastership domains.
+///
+enum class MastershipDomain
+{
+  cfg,
+  motion,
+  rapid
+};
 
-
-  std::ostream& operator<<(std::ostream& os, UseTsp usetsp);
-
-
-  /// @brief RWS mastership domains.
-  ///
-  enum class MastershipDomain
-  {
-    cfg,
-    motion,
-    rapid
-  };
-
-
-  std::ostream& operator<<(std::ostream& os, MastershipDomain domain);
-}
+std::ostream& operator<<(std::ostream& os, MastershipDomain domain);
+}  // namespace abb::rws

--- a/include/abb_librws/rws_cfg.h
+++ b/include/abb_librws/rws_cfg.h
@@ -59,7 +59,6 @@ namespace rws
  */
 namespace cfg
 {
-
 /**
  * \brief Namespace for types belonging to the motion (MOC) domain.
  */
@@ -220,7 +219,7 @@ struct Transmission
    */
   bool rotating_move;
 };
-} // end namespace moc
+}  // end namespace moc
 
 /**
  * \brief Namespace for types belonging to the controller (SYS) domain.
@@ -263,10 +262,10 @@ struct PresentOption
    */
   std::string description;
 };
-} // end namespace sys
+}  // end namespace sys
 
-} // end namespace cfg
-} // end namespace rws
-} // end namespace abb
+}  // end namespace cfg
+}  // end namespace rws
+}  // end namespace abb
 
 #endif

--- a/include/abb_librws/rws_error.h
+++ b/include/abb_librws/rws_error.h
@@ -8,109 +8,89 @@
 
 #include <stdexcept>
 
-
-namespace abb :: rws
+namespace abb ::rws
 {
-  /**
-   * \brief Indicates an RWS error
-   */
-  class RWSError
-  : public std::runtime_error
-  , public boost::exception
+/**
+ * \brief Indicates an RWS error
+ */
+class RWSError : public std::runtime_error, public boost::exception
+{
+protected:
+  explicit RWSError(std::string const& message) : std::runtime_error{ message }
   {
-  protected:
-    explicit RWSError(std::string const& message)
-    : std::runtime_error {message}
-    {
-    }
-  };
+  }
+};
 
-
-  /**
-   * \brief An error occurred when communicating with RWS server.
-   */
-  class CommunicationError
-  : public RWSError
+/**
+ * \brief An error occurred when communicating with RWS server.
+ */
+class CommunicationError : public RWSError
+{
+public:
+  explicit CommunicationError(std::string const& message) : RWSError{ message }
   {
-  public:
-    explicit CommunicationError(std::string const& message)
-    : RWSError {message}
-    {
-    }
-  };
+  }
+};
 
-
-  /**
-   * \brief Protocol errors e.g. invalid/faulty HTTP response.
-   */
-  class ProtocolError
-  : public RWSError
+/**
+ * \brief Protocol errors e.g. invalid/faulty HTTP response.
+ */
+class ProtocolError : public RWSError
+{
+public:
+  explicit ProtocolError(std::string const& message) : RWSError{ message }
   {
-  public:
-    explicit ProtocolError(std::string const& message)
-    : RWSError {message}
-    {
-    }
-  };
+  }
+};
 
-
-  /**
-   * \brief Timeout errors e.g. WebSocket receive timeout.
-   */
-  class TimeoutError
-  : public RWSError
+/**
+ * \brief Timeout errors e.g. WebSocket receive timeout.
+ */
+class TimeoutError : public RWSError
+{
+public:
+  explicit TimeoutError(std::string const& message) : RWSError{ message }
   {
-  public:
-    explicit TimeoutError(std::string const& message)
-    : RWSError {message}
-    {
-    }
-  };
+  }
+};
 
+/**
+ * \brief Error info containing IO signal name.
+ */
+using IoSignalErrorInfo = boost::error_info<struct IoSignalErrorInfoTag, std::string>;
 
-  /**
-   * \brief Error info containing IO signal name.
-   */
-  using IoSignalErrorInfo = boost::error_info<struct IoSignalErrorInfoTag, std::string>;
+/**
+ * \brief Error info containing HTTPStatus.
+ */
+using HttpStatusErrorInfo = boost::error_info<struct HttpStatusErrorInfoTag, Poco::Net::HTTPResponse::HTTPStatus>;
 
+/**
+ * \brief Error info containing HTTP reason phrase.
+ */
+using HttpReasonErrorInfo = boost::error_info<struct HttpReasonErrorInfoTag, std::string>;
 
-  /**
-   * \brief Error info containing HTTPStatus.
-   */
-  using HttpStatusErrorInfo = boost::error_info<struct HttpStatusErrorInfoTag, Poco::Net::HTTPResponse::HTTPStatus>;
+/**
+ * \brief Error info containing an HTTP method.
+ */
+using HttpMethodErrorInfo = boost::error_info<struct HttpMethodErrorInfoTag, std::string>;
 
-  /**
-   * \brief Error info containing HTTP reason phrase.
-   */
-  using HttpReasonErrorInfo = boost::error_info<struct HttpReasonErrorInfoTag, std::string>;
+/**
+ * \brief Error info containing HTTP request content.
+ */
+using HttpRequestContentErrorInfo = boost::error_info<struct HttpRequestContentErrorInfoTag, std::string>;
 
+/**
+ * \brief Error info containing HTTP response content.
+ */
+using HttpResponseContentErrorInfo = boost::error_info<struct HttpResponseContentErrorInfoTag, std::string>;
 
-  /**
-   * \brief Error info containing an HTTP method.
-   */
-  using HttpMethodErrorInfo = boost::error_info<struct HttpMethodErrorInfoTag, std::string>;
+/**
+ * \brief Error info containing an HTTP response.
+ */
+using HttpResponseErrorInfo = boost::error_info<struct HttpResponseErrorInfoTag, POCOResult>;
 
-
-  /**
-   * \brief Error info containing HTTP request content.
-   */
-  using HttpRequestContentErrorInfo = boost::error_info<struct HttpRequestContentErrorInfoTag, std::string>;
-
-
-  /**
-   * \brief Error info containing HTTP response content.
-   */
-  using HttpResponseContentErrorInfo = boost::error_info<struct HttpResponseContentErrorInfoTag, std::string>;
-
-
-  /**
-   * \brief Error info containing an HTTP response.
-   */
-  using HttpResponseErrorInfo = boost::error_info<struct HttpResponseErrorInfoTag, POCOResult>;
-
-
-  /**
-   * \brief Error info containing an URI.
-   */
-  using UriErrorInfo = boost::error_info<struct UriErrorInfoTag, std::string>;
-}
+/**
+ * \brief Error info containing an URI.
+ */
+using UriErrorInfo = boost::error_info<struct UriErrorInfoTag, std::string>;
+}  // namespace abb::rws

--- a/include/abb_librws/rws_poco_client.h
+++ b/include/abb_librws/rws_poco_client.h
@@ -51,261 +51,248 @@ namespace abb
 {
 namespace rws
 {
+/**
+ * \brief A class for a simple client based on POCO.
+ */
+class POCOClient
+{
+public:
   /**
-   * \brief A class for a simple client based on POCO.
+   * \brief A constructor.
+   *
+   * \param session HTTP session. This can be either an HTTPClientSession or an HTTPSClientSession,
+   *  depending on which protocol should be used.
+   * \param username for the username to the remote server's authentication process.
+   * \param password for the password to the remote server's authentication process.
    */
-  class POCOClient
+  POCOClient(Poco::Net::HTTPClientSession& session, const std::string& username, const std::string& password);
+
+  /**
+   * \brief A destructor.
+   */
+  ~POCOClient();
+
+  /**
+   * \brief A method for sending a HTTP GET request.
+   *
+   * \param uri for the URI (path and query).
+   *
+   * \return POCOResult containing the result.
+   */
+  POCOResult httpGet(const std::string& uri);
+
+  /**
+   * \brief A method for sending a HTTP POST request.
+   *
+   * \param uri for the URI (path and query).
+   * \param content for the request's content.
+   *
+   * \return POCOResult containing the result.
+   */
+  POCOResult httpPost(const std::string& uri, const std::string& content = "", const std::string& content_type = "");
+
+  /**
+   * \brief A method for sending a HTTP PUT request.
+   *
+   * \param uri for the URI (path and query).
+   * \param content for the request's content.
+   *
+   * \return POCOResult containing the result.
+   */
+  POCOResult httpPut(const std::string& uri, const std::string& content = "", const std::string& content_type = "");
+
+  /**
+   * \brief A method for sending a HTTP DELETE request.
+   *
+   * \param uri for the URI (path and query).
+   *
+   * \return POCOResult containing the result.
+   */
+  POCOResult httpDelete(const std::string& uri);
+
+  /**
+   * \brief A method for connecting a WebSocket.
+   *
+   * \param uri for the URI (path and query).
+   * \param protocol for the WebSocket protocol.
+   *
+   * \return Newly created client WebSocket.
+   *
+   * \throw \a std::runtime_error if something goes wrong
+   */
+  Poco::Net::WebSocket webSocketConnect(const std::string& uri, const std::string& protocol,
+                                        Poco::Net::HTTPClientSession&& session);
+
+  /**
+   * \brief Method for retrieving the internal log as a text string.
+   *
+   * \param verbose indicating if the log text should be verbose or not.
+   *
+   * \return std::string containing the log text. An empty text string is returned if the log is empty.
+   */
+  std::string getLogText(bool verbose = false) const;
+
+  /**
+   * \brief Method for retrieving only the most recently logged event as a text string.
+   *
+   * \param verbose indicating if the log text should be verbose or not.
+   *
+   * \return std::string containing the log text. An empty text string is returned if the log is empty.
+   */
+  std::string getLogTextLatestEvent(bool verbose = false) const;
+
+private:
+  /**
+   * \brief A struct for containing HTTP info.
+   */
+  struct HTTPInfo
   {
-  public:
     /**
-     * \brief A constructor.
-     *
-     * \param session HTTP session. This can be either an HTTPClientSession or an HTTPSClientSession,
-     *  depending on which protocol should be used.
-     * \param username for the username to the remote server's authentication process.
-     * \param password for the password to the remote server's authentication process.
+     * \brief A struct for containing HTTP request info.
      */
-    POCOClient(Poco::Net::HTTPClientSession& session,
-              const std::string& username,
-              const std::string& password);
-
-    /**
-     * \brief A destructor.
-     */
-    ~POCOClient();
-
-    /**
-     * \brief A method for sending a HTTP GET request.
-     *
-     * \param uri for the URI (path and query).
-     *
-     * \return POCOResult containing the result.
-     */
-    POCOResult httpGet(const std::string& uri);
-
-    /**
-     * \brief A method for sending a HTTP POST request.
-     *
-     * \param uri for the URI (path and query).
-     * \param content for the request's content.
-     *
-     * \return POCOResult containing the result.
-     */
-    POCOResult httpPost(const std::string& uri, const std::string& content = "", const std::string& content_type = "");
-
-    /**
-     * \brief A method for sending a HTTP PUT request.
-     *
-     * \param uri for the URI (path and query).
-     * \param content for the request's content.
-     *
-     * \return POCOResult containing the result.
-     */
-    POCOResult httpPut(const std::string& uri, const std::string& content = "", const std::string& content_type = "");
-
-    /**
-     * \brief A method for sending a HTTP DELETE request.
-     *
-     * \param uri for the URI (path and query).
-     *
-     * \return POCOResult containing the result.
-     */
-    POCOResult httpDelete(const std::string& uri);
-
-    /**
-     * \brief A method for connecting a WebSocket.
-     *
-     * \param uri for the URI (path and query).
-     * \param protocol for the WebSocket protocol.
-     *
-     * \return Newly created client WebSocket.
-     *
-     * \throw \a std::runtime_error if something goes wrong
-     */
-    Poco::Net::WebSocket webSocketConnect(const std::string& uri, const std::string& protocol, Poco::Net::HTTPClientSession&& session);
-
-
-    /**
-     * \brief Method for retrieving the internal log as a text string.
-     *
-     * \param verbose indicating if the log text should be verbose or not.
-     *
-     * \return std::string containing the log text. An empty text string is returned if the log is empty.
-     */
-    std::string getLogText(bool verbose = false) const;
-
-
-    /**
-     * \brief Method for retrieving only the most recently logged event as a text string.
-     *
-     * \param verbose indicating if the log text should be verbose or not.
-     *
-     * \return std::string containing the log text. An empty text string is returned if the log is empty.
-     */
-    std::string getLogTextLatestEvent(bool verbose = false) const;
-
-
-  private:
-    /**
-     * \brief A struct for containing HTTP info.
-     */
-    struct HTTPInfo
+    struct RequestInfo
     {
       /**
-       * \brief A struct for containing HTTP request info.
+       * \brief Method used for the request.
        */
-      struct RequestInfo
-      {
-        /**
-         * \brief Method used for the request.
-         */
-        std::string method;
-
-        /**
-         * \brief URI used for the request.
-         */
-        std::string uri;
-
-        /**
-         * \brief Content used for the request.
-         */
-        std::string content;
-      };
+      std::string method;
 
       /**
-       * \brief A struct for containing HTTP response info.
+       * \brief URI used for the request.
        */
-      struct ResponseInfo
-      {
-        /**
-         * \brief Response status.
-         */
-        Poco::Net::HTTPResponse::HTTPStatus status;
-
-        /**
-         * \brief Response header info.
-         */
-        std::string header_info;
-
-        /**
-         * \brief Response content.
-         */
-        std::string content;
-      };
+      std::string uri;
 
       /**
-       * \brief Info about a HTTP request.
+       * \brief Content used for the request.
        */
-      std::optional<RequestInfo> request;
-
-        /**
-        * \brief Info about a HTTP response.
-        */
-      std::optional<ResponseInfo> response;
-
-
-      /**
-       * \brief A method for adding info from a HTTP request.
-       *
-       * \param request for the HTTP request.
-       * \param request_content for the HTTP request's content.
-       */
-      void addHTTPRequestInfo(const Poco::Net::HTTPRequest& request, const std::string& request_content = "");
-
-      /**
-       * \brief A method for adding info from a HTTP response.
-       *
-       * \param response for the HTTP response.
-       * \param response_content for the HTTP response's content.
-       */
-      void addHTTPResponseInfo(const Poco::Net::HTTPResponse& response, const std::string& response_content = "");
-
-
-      /**
-       * \brief A method to construct a text representation of the result.
-       *
-       * \param verbose indicating if the log text should be verbose or not.
-       * \param indent for indentation.
-       *
-       * \return std::string containing the text representation.
-       */
-      std::string toString(bool verbose = false, size_t indent = 0) const;
+      std::string content;
     };
 
-
     /**
-     * \brief A method for making a HTTP request.
-     *
-     * \param method for the request's method.
-     * \param uri for the URI (path and query).
-     * \param content for the request's content.
-     *
-     * \return POCOResult containing the result.
+     * \brief A struct for containing HTTP response info.
      */
-    POCOResult makeHTTPRequest(const std::string& method,
-                              const std::string& uri = "/",
-                              const std::string& content = "",
-                              const std::string& content_type = "");
+    struct ResponseInfo
+    {
+      /**
+       * \brief Response status.
+       */
+      Poco::Net::HTTPResponse::HTTPStatus status;
+
+      /**
+       * \brief Response header info.
+       */
+      std::string header_info;
+
+      /**
+       * \brief Response content.
+       */
+      std::string content;
+    };
 
     /**
-     * \brief A method for sending and receiving HTTP messages.
+     * \brief Info about a HTTP request.
+     */
+    std::optional<RequestInfo> request;
+
+    /**
+     * \brief Info about a HTTP response.
+     */
+    std::optional<ResponseInfo> response;
+
+    /**
+     * \brief A method for adding info from a HTTP request.
      *
      * \param request for the HTTP request.
-     * \param response for the HTTP response.
-     * \param request_content for the request's content.
-     * \param response_content for the response content.
+     * \param request_content for the HTTP request's content.
      */
-    void sendAndReceive(Poco::Net::HTTPRequest& request,
-                        Poco::Net::HTTPResponse& response,
-                        const std::string& request_content,
-                        std::string& response_content);
+    void addHTTPRequestInfo(const Poco::Net::HTTPRequest& request, const std::string& request_content = "");
 
     /**
-     * \brief A method for performing authentication.
+     * \brief A method for adding info from a HTTP response.
      *
-     * \param request for the HTTP request.
      * \param response for the HTTP response.
-     * \param request_content for the request's content.
-     * \param response_content for the response content.
+     * \param response_content for the HTTP response's content.
      */
-    void authenticate(Poco::Net::HTTPRequest& request,
-                      Poco::Net::HTTPResponse& response,
-                      const std::string& request_content,
-                      std::string& response_content);
+    void addHTTPResponseInfo(const Poco::Net::HTTPResponse& response, const std::string& response_content = "");
 
     /**
-     * \brief A method for extracting and storing information from a cookie string.
+     * \brief A method to construct a text representation of the result.
      *
-     * \param cookie_string for the cookie string.
+     * \param verbose indicating if the log text should be verbose or not.
+     * \param indent for indentation.
+     *
+     * \return std::string containing the text representation.
      */
-    void extractAndStoreCookie(const std::string& cookie_string);
-
-    /**
-     * \brief A HTTP client session.
-     */
-    Poco::Net::HTTPClientSession& http_client_session_;
-
-    /**
-     * \brief HTTP credentials for the remote server's access authentication process.
-     */
-    Poco::Net::HTTPCredentials http_credentials_;
-
-    /**
-     * \brief A container for cookies received from a server.
-     */
-    Poco::Net::NameValueCollection cookies_;
-
-    /**
-     * \brief Static constant for the log's size.
-     */
-    static const size_t LOG_SIZE = 20;
-
-    /**
-     * \brief Container for logging communication results.
-     */
-    std::deque<HTTPInfo> log_;
+    std::string toString(bool verbose = false, size_t indent = 0) const;
   };
-} // end namespace rws
-} // end namespace abb
+
+  /**
+   * \brief A method for making a HTTP request.
+   *
+   * \param method for the request's method.
+   * \param uri for the URI (path and query).
+   * \param content for the request's content.
+   *
+   * \return POCOResult containing the result.
+   */
+  POCOResult makeHTTPRequest(const std::string& method, const std::string& uri = "/", const std::string& content = "",
+                             const std::string& content_type = "");
+
+  /**
+   * \brief A method for sending and receiving HTTP messages.
+   *
+   * \param request for the HTTP request.
+   * \param response for the HTTP response.
+   * \param request_content for the request's content.
+   * \param response_content for the response content.
+   */
+  void sendAndReceive(Poco::Net::HTTPRequest& request, Poco::Net::HTTPResponse& response,
+                      const std::string& request_content, std::string& response_content);
+
+  /**
+   * \brief A method for performing authentication.
+   *
+   * \param request for the HTTP request.
+   * \param response for the HTTP response.
+   * \param request_content for the request's content.
+   * \param response_content for the response content.
+   */
+  void authenticate(Poco::Net::HTTPRequest& request, Poco::Net::HTTPResponse& response,
+                    const std::string& request_content, std::string& response_content);
+
+  /**
+   * \brief A method for extracting and storing information from a cookie string.
+   *
+   * \param cookie_string for the cookie string.
+   */
+  void extractAndStoreCookie(const std::string& cookie_string);
+
+  /**
+   * \brief A HTTP client session.
+   */
+  Poco::Net::HTTPClientSession& http_client_session_;
+
+  /**
+   * \brief HTTP credentials for the remote server's access authentication process.
+   */
+  Poco::Net::HTTPCredentials http_credentials_;
+
+  /**
+   * \brief A container for cookies received from a server.
+   */
+  Poco::Net::NameValueCollection cookies_;
+
+  /**
+   * \brief Static constant for the log's size.
+   */
+  static const size_t LOG_SIZE = 20;
+
+  /**
+   * \brief Container for logging communication results.
+   */
+  std::deque<HTTPInfo> log_;
+};
+}  // end namespace rws
+}  // end namespace abb
 
 #endif

--- a/include/abb_librws/rws_poco_result.h
+++ b/include/abb_librws/rws_poco_result.h
@@ -4,66 +4,60 @@
 
 #include <string>
 
-
-namespace abb :: rws
+namespace abb ::rws
+{
+/**
+ * \brief A struct for containing the result of a communication.
+ */
+struct POCOResult
 {
   /**
-   * \brief A struct for containing the result of a communication.
+   * \brief A constructor.
+   *
+   * \param http_status HTTP response status
+   * \param reason HTTP reason phrase
+   * \param header_info HTTP response header info
+   * \param content HTTP response content
    */
-  struct POCOResult
+  POCOResult(Poco::Net::HTTPResponse::HTTPStatus http_status, std::string const& reason,
+             Poco::Net::NameValueCollection const& header_info, std::string const& content);
+
+  /**
+   * \brief Status of the HTTP response.
+   */
+  Poco::Net::HTTPResponse::HTTPStatus httpStatus() const noexcept
   {
-    /**
-     * \brief A constructor.
-     * 
-     * \param http_status HTTP response status
-     * \param reason HTTP reason phrase
-     * \param header_info HTTP response header info
-     * \param content HTTP response content
-     */
-    POCOResult(Poco::Net::HTTPResponse::HTTPStatus http_status, std::string const& reason,
-      Poco::Net::NameValueCollection const& header_info, std::string const& content);
+    return httpStatus_;
+  }
 
-    
-    /**
-     * \brief Status of the HTTP response.
-     */
-    Poco::Net::HTTPResponse::HTTPStatus httpStatus() const noexcept
-    {
-      return httpStatus_;
-    }
+  /**
+   * \brief HTTP reason phrase.
+   */
+  std::string const& reason() const noexcept
+  {
+    return reason_;
+  }
 
+  /**
+   * \brief HTTP response header info.
+   */
+  auto const& headerInfo() const noexcept
+  {
+    return headerInfo_;
+  }
 
-    /**
-     * \brief HTTP reason phrase.
-     */
-    std::string const& reason() const noexcept
-    {
-      return reason_;
-    }
+  /**
+   * \brief Content of the HTTP response.
+   */
+  std::string const& content() const noexcept
+  {
+    return content_;
+  }
 
-
-    /**
-     * \brief HTTP response header info.
-     */
-    auto const& headerInfo() const noexcept
-    {
-      return headerInfo_;
-    }
-
-
-    /**
-     * \brief Content of the HTTP response.
-     */
-    std::string const& content() const noexcept
-    {
-      return content_;
-    }
-
-
-  private:
-    Poco::Net::HTTPResponse::HTTPStatus httpStatus_;
-    std::string reason_;
-    std::vector<std::pair<std::string, std::string>> headerInfo_;
-    std::string content_;
-  };
-}
+private:
+  Poco::Net::HTTPResponse::HTTPStatus httpStatus_;
+  std::string reason_;
+  std::vector<std::pair<std::string, std::string>> headerInfo_;
+  std::string content_;
+};
+}  // namespace abb::rws

--- a/include/abb_librws/rws_resource.h
+++ b/include/abb_librws/rws_resource.h
@@ -4,159 +4,143 @@
 
 #include <string>
 
-
-namespace abb :: rws
+namespace abb ::rws
+{
+/**
+ * \brief IO signal as a resource.
+ */
+struct IOSignalResource
 {
   /**
-   * \brief IO signal as a resource.
+   * \brief A constructor.
+   *
+   * \param name name of the IO signal.
    */
-  struct IOSignalResource
+  explicit IOSignalResource(std::string const& name) : name(name)
   {
-    /**
-     * \brief A constructor.
-     *
-     * \param name name of the IO signal.
-     */
-    explicit IOSignalResource(std::string const& name)
-    : name(name)
-    {
-    }
-
-    /**
-     * \brief IO signal name.
-     */
-    std::string name;
-  };
-
+  }
 
   /**
-   * \brief A class for representing a RAPID symbol resource.
+   * \brief IO signal name.
    */
-  struct RAPIDSymbolResource
+  std::string name;
+};
+
+/**
+ * \brief A class for representing a RAPID symbol resource.
+ */
+struct RAPIDSymbolResource
+{
+  /**
+   * \brief A constructor.
+   *
+   * \param module specifying the name of the RAPID module containing the symbol.
+   * \param name specifying the name of the RAPID symbol.
+   */
+  RAPIDSymbolResource(const std::string& module, const std::string& name) : module(module), name(name)
   {
-    /**
-     * \brief A constructor.
-     *
-     * \param module specifying the name of the RAPID module containing the symbol.
-     * \param name specifying the name of the RAPID symbol.
-     */
-    RAPIDSymbolResource(const std::string& module, const std::string& name)
-    :
-    module(module),
-    name(name)
-    {}
-
-    /**
-     * \brief The RAPID module name.
-     */
-    std::string module;
-
-    /**
-     * \brief The RAPID symbol name.
-     */
-    std::string name;
-  };
-
+  }
 
   /**
-   * \brief A class for representing a RAPID resource.
+   * \brief The RAPID module name.
    */
-  struct RAPIDResource
-  {
-    /**
-     * \brief A constructor.
-     *
-     * \param task specifying the name of the RAPID task containing the symbol.
-     * \param module specifying the name of the RAPID module containing the symbol.
-     * \param name specifying the name of the RAPID symbol.
-     */
-    RAPIDResource(const std::string& task, const std::string& module, const std::string& name)
-    :
-    task(task),
-    module(module),
-    name(name)
-    {}
-
-    /**
-     * \brief A constructor.
-     *
-     * \param task specifying the name of the RAPID task containing the symbol.
-     * \param symbol specifying the names of the RAPID module and the the symbol.
-     */
-    RAPIDResource(const std::string& task, const RAPIDSymbolResource& symbol)
-    :
-    task(task),
-    module(symbol.module),
-    name(symbol.name)
-    {}
-
-    /**
-     * \brief The RAPID task name.
-     */
-    std::string task;
-
-    /**
-     * \brief The RAPID module name.
-     */
-    std::string module;
-
-    /**
-     * \brief The RAPID symbol name.
-     */
-    std::string name;
-  };
-
+  std::string module;
 
   /**
-   * \brief RAPID execution state subscription resource
+   * \brief The RAPID symbol name.
    */
-  struct RAPIDExecutionStateResource
-  {
-  };
+  std::string name;
+};
 
+/**
+ * \brief A class for representing a RAPID resource.
+ */
+struct RAPIDResource
+{
+  /**
+   * \brief A constructor.
+   *
+   * \param task specifying the name of the RAPID task containing the symbol.
+   * \param module specifying the name of the RAPID module containing the symbol.
+   * \param name specifying the name of the RAPID symbol.
+   */
+  RAPIDResource(const std::string& task, const std::string& module, const std::string& name)
+    : task(task), module(module), name(name)
+  {
+  }
 
   /**
-   * \brief Controller operation mode subscription resource
+   * \brief A constructor.
+   *
+   * \param task specifying the name of the RAPID task containing the symbol.
+   * \param symbol specifying the names of the RAPID module and the the symbol.
    */
-  struct OperationModeResource
+  RAPIDResource(const std::string& task, const RAPIDSymbolResource& symbol)
+    : task(task), module(symbol.module), name(symbol.name)
   {
-  };
-
+  }
 
   /**
-   * \brief Controller state subscription resource
+   * \brief The RAPID task name.
    */
-  struct ControllerStateResource
-  {
-  };
-
+  std::string task;
 
   /**
-   * \brief A class for representing a file resource.
+   * \brief The RAPID module name.
    */
-  struct FileResource
+  std::string module;
+
+  /**
+   * \brief The RAPID symbol name.
+   */
+  std::string name;
+};
+
+/**
+ * \brief RAPID execution state subscription resource
+ */
+struct RAPIDExecutionStateResource
+{
+};
+
+/**
+ * \brief Controller operation mode subscription resource
+ */
+struct OperationModeResource
+{
+};
+
+/**
+ * \brief Controller state subscription resource
+ */
+struct ControllerStateResource
+{
+};
+
+/**
+ * \brief A class for representing a file resource.
+ */
+struct FileResource
+{
+  /**
+   * \brief A constructor.
+   *
+   * \param filename specifying the name of the file.
+   * \param directory specifying the directory of the file on the robot controller (set to $home by default).
+   */
+  FileResource(const std::string& filename, const std::string& directory = v1_0::Identifiers::HOME_DIRECTORY)
+    : filename(filename), directory(directory)
   {
-    /**
-     * \brief A constructor.
-     *
-     * \param filename specifying the name of the file.
-     * \param directory specifying the directory of the file on the robot controller (set to $home by default).
-     */
-    FileResource(const std::string& filename,
-                  const std::string& directory = v1_0::Identifiers::HOME_DIRECTORY)
-    :
-    filename(filename),
-    directory(directory)
-    {}
+  }
 
-    /**
-     * \brief The file's name.
-     */
-    std::string filename;
+  /**
+   * \brief The file's name.
+   */
+  std::string filename;
 
-    /**
-     * \brief The file's directory on the robot controller.
-     */
-    std::string directory;
-  };
-}
+  /**
+   * \brief The file's directory on the robot controller.
+   */
+  std::string directory;
+};
+}  // namespace abb::rws

--- a/include/abb_librws/rws_subscription.h
+++ b/include/abb_librws/rws_subscription.h
@@ -17,443 +17,410 @@
 #include <future>
 #include <chrono>
 
+namespace abb ::rws
+{
+/**
+ * \brief An enum for specifying subscription priority.
+ */
+enum class SubscriptionPriority
+{
+  LOW,     ///< Low priority.
+  MEDIUM,  ///< Medium priority.
+  HIGH     ///< High priority. Only RobotWare 6.05 (or newer) and for IO signals and persistant RAPID variables.
+};
 
-namespace abb :: rws
+class SubscriptionCallback;
+
+/**
+ * \brief Provides the mechanism to open, receive, and close RWS event subscription.
+ */
+class SubscriptionManager
+{
+public:
+  /**
+   * \brief Subscribe to specified resources.
+   *
+   * \param resources list of pairs (resource URIs, priority) to subscribe
+   *
+   * \return Id of the created subscription group.
+   *
+   * \throw \a RWSError if something goes wrong.
+   */
+  virtual std::string openSubscription(std::vector<std::pair<std::string, SubscriptionPriority>> const& resources) = 0;
+
+  /**
+   * \brief End subscription to a specified group.
+   *
+   * \param subscription_group_id id of the subscription group to unsubscribe from.
+   *
+   * \throw \a RWSError if something goes wrong.
+   */
+  virtual void closeSubscription(std::string const& subscription_group_id) = 0;
+
+  /**
+   * \brief Open a WebSocket and start receiving subscription events.
+   *
+   * \param subscription_group_id subscription group id for which to receive event.
+   *
+   * \return WebSocket created to receive the events.
+   *
+   * \throw \a RWSError if something goes wrong.
+   */
+  virtual Poco::Net::WebSocket receiveSubscription(std::string const& subscription_group_id) = 0;
+
+  /**
+   * \brief Get URI for subscribing to an IO signal
+   *
+   * \param io_signal IO signal to subscribe
+   *
+   * \return Subscription URI for \a io_signal
+   */
+  virtual std::string getResourceURI(IOSignalResource const& io_signal) const = 0;
+
+  /**
+   * \brief Get URI for subscribing to a RAPID variable
+   *
+   * \param resource RAPID variable resource
+   *
+   * \return Subscription URI for \a resource
+   */
+  virtual std::string getResourceURI(RAPIDResource const& resource) const = 0;
+
+  /**
+   * \brief Get URI for subscribing to RAPID execution state
+   *
+   * \return Subscription URI
+   */
+  virtual std::string getResourceURI(RAPIDExecutionStateResource const&) const = 0;
+
+  /**
+   * \brief Get URI for subscribing to controller state
+   *
+   * \return Subscription URI
+   */
+  virtual std::string getResourceURI(ControllerStateResource const&) const = 0;
+
+  /**
+   * \brief Get URI for subscribing to operation mode
+   *
+   * \return Subscription URI
+   */
+  virtual std::string getResourceURI(OperationModeResource const&) const = 0;
+
+  /**
+   * \brief Process subscription event.
+   *
+   * Parses the event content \a content, determines event type, and calls the appropriate function in \a callback.
+   *
+   * \param content XML content of the event
+   * \param callback event callback
+   */
+  virtual void processEvent(Poco::AutoPtr<Poco::XML::Document> content, SubscriptionCallback& callback) const = 0;
+};
+
+/**
+ * \brief Subscription resource that has URI and priority.
+ */
+class SubscriptionResource
+{
+public:
+  template <typename T>
+  SubscriptionResource(T const& resource, SubscriptionPriority priority)
+    : resource_{ new ResourceImpl<T>{ resource } }, priority_{ priority }
+  {
+  }
+
+  std::string getURI(SubscriptionManager const& subscription_manager) const
+  {
+    return resource_->getURI(subscription_manager);
+  }
+
+  SubscriptionPriority getPriority() const noexcept
+  {
+    return priority_;
+  }
+
+private:
+  struct ResourceInterface
+  {
+    virtual std::string getURI(SubscriptionManager const& subscription_manager) const = 0;
+    virtual ~ResourceInterface(){};
+  };
+
+  template <typename T>
+  class ResourceImpl : public ResourceInterface
+  {
+  public:
+    ResourceImpl(T const& resource) : resource_{ resource }
+    {
+    }
+
+    std::string getURI(SubscriptionManager const& subscription_manager) const override
+    {
+      return subscription_manager.getResourceURI(resource_);
+    }
+
+  private:
+    T const resource_;
+  };
+
+  std::shared_ptr<ResourceInterface> resource_;
+
+  /**
+   * \brief Priority of the subscription.
+   */
+  SubscriptionPriority priority_;
+};
+
+using SubscriptionResources = std::vector<SubscriptionResource>;
+
+/**
+ * \brief Event received when an IO signal state changes.
+ */
+struct IOSignalStateEvent
+{
+  /// \brief IO signal name
+  std::string signal;
+
+  /**
+   * \brief IO signal value
+   */
+  std::string value;
+};
+
+/**
+ * \brief Event received when an IO signal state changes.
+ */
+struct RAPIDExecutionStateEvent
 {
   /**
-   * \brief An enum for specifying subscription priority.
+   * \brief RAPID execution state
    */
-  enum class SubscriptionPriority
-  {
-    LOW,    ///< Low priority.
-    MEDIUM, ///< Medium priority.
-    HIGH    ///< High priority. Only RobotWare 6.05 (or newer) and for IO signals and persistant RAPID variables.
-  };
+  rw::RAPIDExecutionState state;
+};
 
-
-  class SubscriptionCallback;
-
-
+/**
+ * \brief Event received when controller state changes.
+ */
+struct ControllerStateEvent
+{
   /**
-   * \brief Provides the mechanism to open, receive, and close RWS event subscription.
+   * \brief Controller state
    */
-  class SubscriptionManager
-  {
-  public:
-    /**
-     * \brief Subscribe to specified resources.
-     *
-     * \param resources list of pairs (resource URIs, priority) to subscribe
-     *
-     * \return Id of the created subscription group.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    virtual std::string openSubscription(std::vector<std::pair<std::string, SubscriptionPriority>> const& resources) = 0;
+  rw::ControllerState state;
+};
 
-    /**
-     * \brief End subscription to a specified group.
-     *
-     * \param subscription_group_id id of the subscription group to unsubscribe from.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    virtual void closeSubscription(std::string const& subscription_group_id) = 0;
-
-    /**
-     * \brief Open a WebSocket and start receiving subscription events.
-     *
-     * \param subscription_group_id subscription group id for which to receive event.
-     *
-     * \return WebSocket created to receive the events.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    virtual Poco::Net::WebSocket receiveSubscription(std::string const& subscription_group_id) = 0;
-
-    /**
-     * \brief Get URI for subscribing to an IO signal
-     *
-     * \param io_signal IO signal to subscribe
-     *
-     * \return Subscription URI for \a io_signal
-     */
-    virtual std::string getResourceURI(IOSignalResource const& io_signal) const = 0;
-
-    /**
-     * \brief Get URI for subscribing to a RAPID variable
-     *
-     * \param resource RAPID variable resource
-     *
-     * \return Subscription URI for \a resource
-     */
-    virtual std::string getResourceURI(RAPIDResource const& resource) const = 0;
-
-    /**
-     * \brief Get URI for subscribing to RAPID execution state
-     *
-     * \return Subscription URI
-     */
-    virtual std::string getResourceURI(RAPIDExecutionStateResource const&) const = 0;
-
-    /**
-     * \brief Get URI for subscribing to controller state
-     *
-     * \return Subscription URI
-     */
-    virtual std::string getResourceURI(ControllerStateResource const&) const = 0;
-
-
-    /**
-     * \brief Get URI for subscribing to operation mode
-     *
-     * \return Subscription URI
-     */
-    virtual std::string getResourceURI(OperationModeResource const&) const = 0;
-
-    /**
-     * \brief Process subscription event.
-     *
-     * Parses the event content \a content, determines event type, and calls the appropriate function in \a callback.
-     *
-     * \param content XML content of the event
-     * \param callback event callback
-     */
-    virtual void processEvent(Poco::AutoPtr<Poco::XML::Document> content, SubscriptionCallback& callback) const = 0;
-  };
-
-
+/**
+ * \brief Event received when operation mode changes.
+ */
+struct OperationModeEvent
+{
   /**
-   * \brief Subscription resource that has URI and priority.
+   * \brief Operation mode
    */
-  class SubscriptionResource
-  {
-  public:
-    template <typename T>
-    SubscriptionResource(T const& resource, SubscriptionPriority priority)
-    : resource_ {new ResourceImpl<T> {resource}}
-    , priority_ {priority}
-    {
-    }
+  rw::OperationMode mode;
+};
 
-    std::string getURI(SubscriptionManager const& subscription_manager) const
-    {
-      return resource_->getURI(subscription_manager);
-    }
+/**
+ * \brief Defines callbacks for different types of RWS subscription events.
+ */
+class SubscriptionCallback
+{
+public:
+  virtual void processEvent(IOSignalStateEvent const& event);
+  virtual void processEvent(RAPIDExecutionStateEvent const& event);
+  virtual void processEvent(ControllerStateEvent const& event);
+  virtual void processEvent(OperationModeEvent const& event);
+};
 
-    SubscriptionPriority getPriority() const noexcept
-    {
-      return priority_;
-    }
-
-  private:
-    struct ResourceInterface
-    {
-      virtual std::string getURI(SubscriptionManager const& subscription_manager) const = 0;
-      virtual ~ResourceInterface() {};
-    };
-
-    template <typename T>
-    class ResourceImpl
-    : public ResourceInterface
-    {
-    public:
-      ResourceImpl(T const& resource)
-      : resource_ {resource}
-      {
-      }
-
-      std::string getURI(SubscriptionManager const& subscription_manager) const override
-      {
-        return subscription_manager.getResourceURI(resource_);
-      }
-
-    private:
-      T const resource_;
-    };
-
-
-    std::shared_ptr<ResourceInterface> resource_;
-
-    /**
-     * \brief Priority of the subscription.
-     */
-    SubscriptionPriority priority_;
-  };
-
-
-  using SubscriptionResources = std::vector<SubscriptionResource>;
-
-
+/**
+ * \brief Receives RWS subscription events.
+ */
+class SubscriptionReceiver
+{
+public:
   /**
-   * \brief Event received when an IO signal state changes.
-   */
-  struct IOSignalStateEvent
-  {
-    /// \brief IO signal name
-    std::string signal;
-
-    /**
-     * \brief IO signal value
-     */
-    std::string value;
-  };
-
-
-  /**
-   * \brief Event received when an IO signal state changes.
-   */
-  struct RAPIDExecutionStateEvent
-  {
-    /**
-     * \brief RAPID execution state
-     */
-    rw::RAPIDExecutionState state;
-  };
-
-
-  /**
-   * \brief Event received when controller state changes.
-   */
-  struct ControllerStateEvent
-  {
-    /**
-     * \brief Controller state
-     */
-    rw::ControllerState state;
-  };
-
-
-  /**
-   * \brief Event received when operation mode changes.
-   */
-  struct OperationModeEvent
-  {
-    /**
-     * \brief Operation mode
-     */
-    rw::OperationMode mode;
-  };
-
-
-  /**
-   * \brief Defines callbacks for different types of RWS subscription events.
-   */
-  class SubscriptionCallback
-  {
-  public:
-    virtual void processEvent(IOSignalStateEvent const& event);
-    virtual void processEvent(RAPIDExecutionStateEvent const& event);
-    virtual void processEvent(ControllerStateEvent const& event);
-    virtual void processEvent(OperationModeEvent const& event);
-  };
-
-
-  /**
-   * \brief Receives RWS subscription events.
-   */
-  class SubscriptionReceiver
-  {
-  public:
-    /**
-     * \brief Prepares to receive events from a specified subscription WebSocket.
-     *
-     * \param subscription_manager used to initiate WebSocket connection and parse incomoing message content
-     * \param subscription_group_id id of the subscription group for which to receive events
-     */
-    explicit SubscriptionReceiver(SubscriptionManager& subscription_manager, std::string const& subscription_group_id);
-
-
-    /**
-     * \brief \a SubscriptionReceiver objects are moveable, but not copyable.
-     */
-    SubscriptionReceiver(SubscriptionReceiver&&) = default;
-
-
-    /**
-     * \brief Closes the WebSocket connection but does not delete the subscription.
-     */
-    ~SubscriptionReceiver();
-
-
-    /**
-     * \brief Waits for a subscription event.
-     *
-     * \param callback callback to be called when an event arrives
-     * \param timeout wait timeout
-     *
-     * \return true if the connection is still alive, false if the connection has been closed.
-     *
-     * \throw \a TimeoutError if waiting time exceeds \a timeout.
-     */
-    bool waitForEvent(SubscriptionCallback& callback, std::chrono::microseconds timeout = DEFAULT_SUBSCRIPTION_TIMEOUT);
-
-
-    /**
-     * \brief Shutdown the active subscription connection.
-     *
-     * If waitForEvent() is being executed on a different thread, it will return or throw.
-     * It does not delete the subscription from the controller.
-     *
-     * The preferred way to close the subscription is the destruction of the \a SubscriptionGroup object.
-     * This function can be used to force the connection to close immediately in
-     * case the robot controller is not responding.
-     *
-     * This function will return immediately and does not block until an active waitForEvent() has finished.
-     *
-     */
-    void shutdown();
-
-
-  private:
-    /**
-     * \brief Default RWS subscription timeout [microseconds].
-     */
-    static const std::chrono::microseconds DEFAULT_SUBSCRIPTION_TIMEOUT;
-
-    /**
-     * \brief Static constant for the socket's buffer size.
-     */
-    static const size_t BUFFER_SIZE = 1024;
-
-    /**
-     * \brief A buffer for a Subscription.
-     */
-    char websocket_buffer_[BUFFER_SIZE];
-
-    SubscriptionManager& subscription_manager_;
-
-    /**
-     * \brief WebSocket for receiving events.
-     */
-    Poco::Net::WebSocket webSocket_;
-
-    /**
-     * \brief Parser for XML in WebSocket frames.
-     */
-    Poco::XML::DOMParser parser_;
-
-
-    bool webSocketReceiveFrame(WebSocketFrame& frame, std::chrono::microseconds timeout);
-  };
-
-
-  /**
-   * \brief Manages an RWS subscription group.
-   */
-  class SubscriptionGroup
-  {
-  public:
-    /**
-     * \brief Registers a subscription at the server.
-     *
-     * \param subscription_manager an interface to control the subscription
-     * \param resources list of resources to subscribe
-     */
-    explicit SubscriptionGroup(SubscriptionManager& subscription_manager, SubscriptionResources const& resources);
-
-
-    /**
-     * \a SubscriptionGroup objects are moveable, but not copyable.
-     */
-    SubscriptionGroup(SubscriptionGroup&&);
-
-
-    /**
-     * \brief Ends an active subscription.
-     */
-    ~SubscriptionGroup();
-
-    /**
-     * \brief Get ID of the subscription group.
-     *
-     * \return ID of the subscription group.
-     */
-    std::string const& id() const noexcept
-    {
-      return subscription_group_id_;
-    }
-
-
-    /**
-     * \brief Establish WebSocket connection ans start receiving subscription events.
-     *
-     * \return \a SubscriptionReceiver object that can be used to receive events.
-     */
-    SubscriptionReceiver receive() const;
-
-
-    /**
-     * \brief Close the subscription.
-     *
-     * Closes the subscription as if the destructor was called.
-     * The \a id() will become empty and the subsequent calls to \a receive() will fail.
-     * This function can be used to close the subscription before destroying the object,
-     * and to catch possible errors, which would be problematic with the destructor.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    void close();
-
-
-    /**
-     * \brief Detach the object from the subscription group.
-     *
-     * Detaches the object from the actual subscription group, without attempting to close it.
-     * The \a id() will become empty and the subsequent calls to \a receive() will fail.
-     * This is useful if closing the subscription group fails, but you want to continue.
-     */
-    void detach() noexcept;
-
-
-  private:
-    static std::vector<std::pair<std::string, SubscriptionPriority>> getURI(
-      SubscriptionManager& subscription_manager, SubscriptionResources const& resources);
-
-
-    SubscriptionManager& subscription_manager_;
-
-    /**
-     * \brief A subscription group id.
-     */
-    std::string subscription_group_id_;
-  };
-
-
-  /**
-   * \brief Wait for a subscription event of a specific type.
+   * \brief Prepares to receive events from a specified subscription WebSocket.
    *
-   * \tparam T type of an event to wait for
+   * \param subscription_manager used to initiate WebSocket connection and parse incomoing message content
+   * \param subscription_group_id id of the subscription group for which to receive events
+   */
+  explicit SubscriptionReceiver(SubscriptionManager& subscription_manager, std::string const& subscription_group_id);
+
+  /**
+   * \brief \a SubscriptionReceiver objects are moveable, but not copyable.
+   */
+  SubscriptionReceiver(SubscriptionReceiver&&) = default;
+
+  /**
+   * \brief Closes the WebSocket connection but does not delete the subscription.
+   */
+  ~SubscriptionReceiver();
+
+  /**
+   * \brief Waits for a subscription event.
    *
-   * \param receiver RWS subscription receiver
+   * \param callback callback to be called when an event arrives
    * \param timeout wait timeout
    *
-   * \return \a std::future with the received event.
+   * \return true if the connection is still alive, false if the connection has been closed.
    *
-   * \throw \a CommunicationError if the subscription WebSocket connection is closed while waiting for the event.
    * \throw \a TimeoutError if waiting time exceeds \a timeout.
    */
-  template <typename T>
-  inline std::future<T> waitForEvent(SubscriptionReceiver& receiver, std::chrono::microseconds timeout)
+  bool waitForEvent(SubscriptionCallback& callback, std::chrono::microseconds timeout = DEFAULT_SUBSCRIPTION_TIMEOUT);
+
+  /**
+   * \brief Shutdown the active subscription connection.
+   *
+   * If waitForEvent() is being executed on a different thread, it will return or throw.
+   * It does not delete the subscription from the controller.
+   *
+   * The preferred way to close the subscription is the destruction of the \a SubscriptionGroup object.
+   * This function can be used to force the connection to close immediately in
+   * case the robot controller is not responding.
+   *
+   * This function will return immediately and does not block until an active waitForEvent() has finished.
+   *
+   */
+  void shutdown();
+
+private:
+  /**
+   * \brief Default RWS subscription timeout [microseconds].
+   */
+  static const std::chrono::microseconds DEFAULT_SUBSCRIPTION_TIMEOUT;
+
+  /**
+   * \brief Static constant for the socket's buffer size.
+   */
+  static const size_t BUFFER_SIZE = 1024;
+
+  /**
+   * \brief A buffer for a Subscription.
+   */
+  char websocket_buffer_[BUFFER_SIZE];
+
+  SubscriptionManager& subscription_manager_;
+
+  /**
+   * \brief WebSocket for receiving events.
+   */
+  Poco::Net::WebSocket webSocket_;
+
+  /**
+   * \brief Parser for XML in WebSocket frames.
+   */
+  Poco::XML::DOMParser parser_;
+
+  bool webSocketReceiveFrame(WebSocketFrame& frame, std::chrono::microseconds timeout);
+};
+
+/**
+ * \brief Manages an RWS subscription group.
+ */
+class SubscriptionGroup
+{
+public:
+  /**
+   * \brief Registers a subscription at the server.
+   *
+   * \param subscription_manager an interface to control the subscription
+   * \param resources list of resources to subscribe
+   */
+  explicit SubscriptionGroup(SubscriptionManager& subscription_manager, SubscriptionResources const& resources);
+
+  /**
+   * \a SubscriptionGroup objects are moveable, but not copyable.
+   */
+  SubscriptionGroup(SubscriptionGroup&&);
+
+  /**
+   * \brief Ends an active subscription.
+   */
+  ~SubscriptionGroup();
+
+  /**
+   * \brief Get ID of the subscription group.
+   *
+   * \return ID of the subscription group.
+   */
+  std::string const& id() const noexcept
   {
-    struct Callback : rws::SubscriptionCallback
-    {
-        void processEvent(T const& event) override
-        {
-            event_ = event;
-        }
-
-        T event_;
-    };
-
-
-    return std::async(std::launch::async,
-        [&receiver, timeout] {
-            Callback callback;
-            if (!receiver.waitForEvent(callback, timeout))
-              BOOST_THROW_EXCEPTION(CommunicationError {"WebSocket connection shut down when waiting for a subscription event"});
-            return callback.event_;
-        }
-    );
+    return subscription_group_id_;
   }
+
+  /**
+   * \brief Establish WebSocket connection ans start receiving subscription events.
+   *
+   * \return \a SubscriptionReceiver object that can be used to receive events.
+   */
+  SubscriptionReceiver receive() const;
+
+  /**
+   * \brief Close the subscription.
+   *
+   * Closes the subscription as if the destructor was called.
+   * The \a id() will become empty and the subsequent calls to \a receive() will fail.
+   * This function can be used to close the subscription before destroying the object,
+   * and to catch possible errors, which would be problematic with the destructor.
+   *
+   * \throw \a RWSError if something goes wrong.
+   */
+  void close();
+
+  /**
+   * \brief Detach the object from the subscription group.
+   *
+   * Detaches the object from the actual subscription group, without attempting to close it.
+   * The \a id() will become empty and the subsequent calls to \a receive() will fail.
+   * This is useful if closing the subscription group fails, but you want to continue.
+   */
+  void detach() noexcept;
+
+private:
+  static std::vector<std::pair<std::string, SubscriptionPriority>> getURI(SubscriptionManager& subscription_manager,
+                                                                          SubscriptionResources const& resources);
+
+  SubscriptionManager& subscription_manager_;
+
+  /**
+   * \brief A subscription group id.
+   */
+  std::string subscription_group_id_;
+};
+
+/**
+ * \brief Wait for a subscription event of a specific type.
+ *
+ * \tparam T type of an event to wait for
+ *
+ * \param receiver RWS subscription receiver
+ * \param timeout wait timeout
+ *
+ * \return \a std::future with the received event.
+ *
+ * \throw \a CommunicationError if the subscription WebSocket connection is closed while waiting for the event.
+ * \throw \a TimeoutError if waiting time exceeds \a timeout.
+ */
+template <typename T>
+inline std::future<T> waitForEvent(SubscriptionReceiver& receiver, std::chrono::microseconds timeout)
+{
+  struct Callback : rws::SubscriptionCallback
+  {
+    void processEvent(T const& event) override
+    {
+      event_ = event;
+    }
+
+    T event_;
+  };
+
+  return std::async(std::launch::async, [&receiver, timeout] {
+    Callback callback;
+    if (!receiver.waitForEvent(callback, timeout))
+      BOOST_THROW_EXCEPTION(
+          CommunicationError{ "WebSocket connection shut down when waiting for a subscription event" });
+    return callback.event_;
+  });
 }
+}  // namespace abb::rws

--- a/include/abb_librws/system_constants.h
+++ b/include/abb_librws/system_constants.h
@@ -292,7 +292,7 @@ struct SystemConstants
   };
 };
 
-} // end namespace rws
-} // end namespace abb
+}  // end namespace rws
+}  // end namespace abb
 
 #endif

--- a/include/abb_librws/v1_0/rw/io.h
+++ b/include/abb_librws/v1_0/rw/io.h
@@ -3,97 +3,88 @@
 #include <abb_librws/v1_0/rws_client.h>
 #include <abb_librws/common/rw/io.h>
 
-
-namespace abb :: rws :: v1_0 :: rw :: io
+namespace abb ::rws ::v1_0 ::rw ::io
 {
-    using namespace abb::rws::rw::io;
+using namespace abb::rws::rw::io;
 
+/**
+ * \brief Get values of all IO signals.
+ *
+ * \param client RWS client.
+ *
+ * \return Mapping from IO signal names to values.
+ */
+IOSignalInfo getIOSignals(RWSClient& client);
 
-    /**
-     * \brief Get values of all IO signals.
-     *
-     * \param client RWS client.
-     *
-     * \return Mapping from IO signal names to values.
-     */
-    IOSignalInfo getIOSignals(RWSClient& client);
+/**
+ * \brief A function for retrieving the value of an IO signal.
+ *
+ * \param client RWS client
+ * \param iosignal for the name of the IO signal.
+ *
+ * \return std::string containing the IO signal's value (empty if not found).
+ */
+std::string getIOSignal(RWSClient& client, const std::string& iosignal);
 
-    /**
-     * \brief A function for retrieving the value of an IO signal.
-     *
-     * \param client RWS client
-     * \param iosignal for the name of the IO signal.
-     *
-     * \return std::string containing the IO signal's value (empty if not found).
-     */
-    std::string getIOSignal(RWSClient& client, const std::string& iosignal);
+/**
+ * \brief A function for setting the value of an IO signal.
+ *
+ * \param client RWS client.
+ * \param iosignal for the IO signal's name.
+ * \param value for the IO signal's new value.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+void setIOSignal(RWSClient& client, const std::string& iosignal, const std::string& value);
 
+/// @brief Get value of a digital signal
+///
+/// @param client RWS client
+/// @param signal_name Name of the signal
+///
+/// @return Value of the requested digital signal
+///
+bool getDigitalSignal(RWSClient& client, std::string const& signal_name);
 
-     /**
-     * \brief A function for setting the value of an IO signal.
-     *
-     * \param client RWS client.
-     * \param iosignal for the IO signal's name.
-     * \param value for the IO signal's new value.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    void setIOSignal(RWSClient& client, const std::string& iosignal, const std::string& value);
+/// @brief Get value of an analog signal
+///
+/// @param client RWS client
+/// @param signal_name Name of the signal
+///
+/// @return Value of the requested analog signal
+///
+float getAnalogSignal(RWSClient& client, std::string const& signal_name);
 
+/// @brief Get value of a group signal
+///
+/// @param client RWS client
+/// @param signal_name Name of the signal
+///
+/// @return Value of the requested group signal
+///
+std::uint32_t getGroupSignal(RWSClient& client, std::string const& signal_name);
 
-    /// @brief Get value of a digital signal
-    ///
-    /// @param client RWS client
-    /// @param signal_name Name of the signal
-    ///
-    /// @return Value of the requested digital signal
-    ///
-    bool getDigitalSignal(RWSClient& client, std::string const& signal_name);
+/// @brief Set value of a digital signal
+///
+/// @param client RWS client
+/// @param signal_name Name of the signal
+/// @param value New value of the signal
+///
+void setDigitalSignal(RWSClient& client, std::string const& signal_name, bool value);
 
+/// @brief Set value of an analog signal
+///
+/// @param client RWS client
+/// @param signal_name Name of the signal
+/// @param value New value of the signal
+///
+void setAnalogSignal(RWSClient& client, std::string const& signal_name, float value);
 
-    /// @brief Get value of an analog signal
-    ///
-    /// @param client RWS client
-    /// @param signal_name Name of the signal
-    ///
-    /// @return Value of the requested analog signal
-    ///
-    float getAnalogSignal(RWSClient& client, std::string const& signal_name);
-
-
-    /// @brief Get value of a group signal
-    ///
-    /// @param client RWS client
-    /// @param signal_name Name of the signal
-    ///
-    /// @return Value of the requested group signal
-    ///
-    std::uint32_t getGroupSignal(RWSClient& client, std::string const& signal_name);
-
-
-    /// @brief Set value of a digital signal
-    ///
-    /// @param client RWS client
-    /// @param signal_name Name of the signal
-    /// @param value New value of the signal
-    ///
-    void setDigitalSignal(RWSClient& client, std::string const& signal_name, bool value);
-
-
-    /// @brief Set value of an analog signal
-    ///
-    /// @param client RWS client
-    /// @param signal_name Name of the signal
-    /// @param value New value of the signal
-    ///
-    void setAnalogSignal(RWSClient& client, std::string const& signal_name, float value);
-
-
-    /// @brief Set value of a group signal
-    ///
-    /// @param client RWS client
-    /// @param signal_name Name of the signal
-    /// @param value New value of the signal
-    ///
-    void setGroupSignal(RWSClient& client, std::string const& signal_name, std::uint32_t value);
-}
+/// @brief Set value of a group signal
+///
+/// @param client RWS client
+/// @param signal_name Name of the signal
+/// @param value New value of the signal
+///
+void setGroupSignal(RWSClient& client, std::string const& signal_name, std::uint32_t value);
+}  // namespace abb::rws::v1_0::rw::io

--- a/include/abb_librws/v1_0/rw/panel.h
+++ b/include/abb_librws/v1_0/rw/panel.h
@@ -7,74 +7,68 @@
 
 #include <string>
 
-
-namespace abb :: rws :: v1_0 :: rw
+namespace abb ::rws ::v1_0 ::rw
 {
-    using namespace rws::rw;
+using namespace rws::rw;
 }
 
-
-namespace abb :: rws :: v1_0 :: rw :: panel
+namespace abb ::rws ::v1_0 ::rw ::panel
 {
-    /**
-     * \brief A function for retrieving the controller state.
-     *
-     * \param client RWS client
-     *
-     * \return RWSResult containing the result.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    ControllerState getControllerState(RWSClient& client);
+/**
+ * \brief A function for retrieving the controller state.
+ *
+ * \param client RWS client
+ *
+ * \return RWSResult containing the result.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+ControllerState getControllerState(RWSClient& client);
 
+/**
+ * \brief Set controller state
+ *
+ * \param client RWS client
+ * \param state new controller state
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+void setControllerState(RWSClient& client, ControllerState state);
 
-    /**
-     * \brief Set controller state
-     *
-     * \param client RWS client
-     * \param state new controller state
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    void setControllerState(RWSClient& client, ControllerState state);
+/**
+ * \brief A function for retrieving the operation mode of the controller.
+ *
+ * \param client RWS client
+ *
+ * \return RWSResult containing the result.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+OperationMode getOperationMode(RWSClient& client);
 
+/**
+ * \brief A function for retrieving the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
+ *
+ * \param client RWS client
+ *
+ * \return RWSResult containing the result.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+unsigned getSpeedRatio(RWSClient& client);
 
-    /**
-     * \brief A function for retrieving the operation mode of the controller.
-     *
-     * \param client RWS client
-     *
-     * \return RWSResult containing the result.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    OperationMode getOperationMode(RWSClient& client);
-
-
-    /**
-     * \brief A function for retrieving the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
-     *
-     * \param client RWS client
-     *
-     * \return RWSResult containing the result.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    unsigned getSpeedRatio(RWSClient& client);
-
-
-    /**
-     * \brief A function for setting the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
-     *
-     * Note: The ratio must be an integer in the range [0, 100] (ie: inclusive).
-     *
-     * \param client RWS client
-     * \param ratio specifying the new ratio.
-     *
-     * \return RWSResult containing the result.
-     *
-     * \throw std::out_of_range if argument is out of range.
-     * \throw \a RWSError if something goes wrong.
-     */
-    void setSpeedRatio(RWSClient& client, unsigned int ratio);
-}
+/**
+ * \brief A function for setting the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
+ *
+ * Note: The ratio must be an integer in the range [0, 100] (ie: inclusive).
+ *
+ * \param client RWS client
+ * \param ratio specifying the new ratio.
+ *
+ * \return RWSResult containing the result.
+ *
+ * \throw std::out_of_range if argument is out of range.
+ * \throw \a RWSError if something goes wrong.
+ */
+void setSpeedRatio(RWSClient& client, unsigned int ratio);
+}  // namespace abb::rws::v1_0::rw::panel

--- a/include/abb_librws/v1_0/rw/rapid.h
+++ b/include/abb_librws/v1_0/rw/rapid.h
@@ -7,152 +7,151 @@
 
 #include <string>
 
-
-namespace abb :: rws :: v1_0 :: rw
+namespace abb ::rws ::v1_0 ::rw
 {
-    using namespace rws::rw;
+using namespace rws::rw;
 }
 
-
-namespace abb :: rws :: v1_0 :: rw :: rapid
+namespace abb ::rws ::v1_0 ::rw ::rapid
 {
-    /**
-     * \brief A function for retrieving the execution state of RAPID.
-     *
-     * https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_get_page.html
-     *
-     * \param client RWS client
-     *
-     * \return Current RAPID execution state.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    RAPIDExecutionInfo getRAPIDExecution(RWSClient& client);
+/**
+ * \brief A function for retrieving the execution state of RAPID.
+ *
+ * https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_get_page.html
+ *
+ * \param client RWS client
+ *
+ * \return Current RAPID execution state.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+RAPIDExecutionInfo getRAPIDExecution(RWSClient& client);
 
-    /**
-     * \brief A function for starting RAPID execution in the robot controller.
-     *
-     * \param client RWS client
-     *
-     * There can be a delay between the function returns and when the RAPID program enters the "running" state.
-     *
-     * \throw \a std::runtime_error if something goes wrong.
-     */
-    void startRAPIDExecution(RWSClient& client);
+/**
+ * \brief A function for starting RAPID execution in the robot controller.
+ *
+ * \param client RWS client
+ *
+ * There can be a delay between the function returns and when the RAPID program enters the "running" state.
+ *
+ * \throw \a std::runtime_error if something goes wrong.
+ */
+void startRAPIDExecution(RWSClient& client);
 
-    /**
-     * \brief A function for stopping RAPID execution in the robot controller.
-     *
-     * https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_stop_page.html
-     *
-     * There can be a delay between the function returns and when the RAPID program enters the "stopped" state.
-     *
-     * \param client RWS client
-     * \param stopmode stop mode
-     * \param usetsp which tasks to stop (?)
-     *
-     * \throw \a std::runtime_error if something goes wrong.
-     */
-    void stopRAPIDExecution(RWSClient& client, StopMode stopmode = StopMode::stop, UseTsp usetsp = UseTsp::normal);
+/**
+ * \brief A function for stopping RAPID execution in the robot controller.
+ *
+ * https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_stop_page.html
+ *
+ * There can be a delay between the function returns and when the RAPID program enters the "stopped" state.
+ *
+ * \param client RWS client
+ * \param stopmode stop mode
+ * \param usetsp which tasks to stop (?)
+ *
+ * \throw \a std::runtime_error if something goes wrong.
+ */
+void stopRAPIDExecution(RWSClient& client, StopMode stopmode = StopMode::stop, UseTsp usetsp = UseTsp::normal);
 
-    /**
-     * \brief A function for reseting the RAPID program pointer in the robot controller.
-     *
-     * \param client RWS client
-     *
-     * \throw \a std::runtime_error if something goes wrong.
-     */
-    void resetRAPIDProgramPointer(RWSClient& client);
+/**
+ * \brief A function for reseting the RAPID program pointer in the robot controller.
+ *
+ * \param client RWS client
+ *
+ * \throw \a std::runtime_error if something goes wrong.
+ */
+void resetRAPIDProgramPointer(RWSClient& client);
 
-    /**
-     * \brief A function for retrieving information about the RAPID modules of a RAPID task defined in the robot controller.
-     *
-     * \param client RWS client
-     *
-     * \return \a std::vector<RAPIDModuleInfo> containing the RAPID modules information.
-     *
-     * \throw \a std::runtime_error if something goes wrong.
-     */
-    std::vector<RAPIDModuleInfo> getRAPIDModulesInfo(RWSClient& client, const std::string& task);
+/**
+ * \brief A function for retrieving information about the RAPID modules of a RAPID task defined in the robot controller.
+ *
+ * \param client RWS client
+ *
+ * \return \a std::vector<RAPIDModuleInfo> containing the RAPID modules information.
+ *
+ * \throw \a std::runtime_error if something goes wrong.
+ */
+std::vector<RAPIDModuleInfo> getRAPIDModulesInfo(RWSClient& client, const std::string& task);
 
-    /**
-     * \brief A function for retrieving information about the RAPID tasks defined in the robot controller.
-     *
-     * \param client RWS client
-     *
-     * \return \a std::vector<RAPIDTaskInfo> containing the RAPID tasks information.
-     *
-     * \throw \a std::runtime_error if something goes wrong.
-     */
-    std::vector<RAPIDTaskInfo> getRAPIDTasks(RWSClient& client);
+/**
+ * \brief A function for retrieving information about the RAPID tasks defined in the robot controller.
+ *
+ * \param client RWS client
+ *
+ * \return \a std::vector<RAPIDTaskInfo> containing the RAPID tasks information.
+ *
+ * \throw \a std::runtime_error if something goes wrong.
+ */
+std::vector<RAPIDTaskInfo> getRAPIDTasks(RWSClient& client);
 
-    /**
-     * \brief A function for retrieving the data of a RAPID symbol.
-     *
-     * \param client RWS client
-     * \param resource specifies the RAPID task, module, and symbol name for the RAPID resource.
-     * \param data variable for receiving the symbol value.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    void getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource, RAPIDSymbolDataAbstract& data);
+/**
+ * \brief A function for retrieving the data of a RAPID symbol.
+ *
+ * \param client RWS client
+ * \param resource specifies the RAPID task, module, and symbol name for the RAPID resource.
+ * \param data variable for receiving the symbol value.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+void getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource, RAPIDSymbolDataAbstract& data);
 
-    /**
-     * \brief A function for retrieving the data of a RAPID symbol in raw text format.
-     *
-     * See the corresponding "setRAPIDSymbolData(...)" function for examples of RAPID symbols in raw text format.
-     *
-     * \param client RWS client
-     * \param resource specifies the RAPID task, module, and symbol name for the RAPID resource.
-     *
-     * \return String containing the data.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    std::string getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource);
+/**
+ * \brief A function for retrieving the data of a RAPID symbol in raw text format.
+ *
+ * See the corresponding "setRAPIDSymbolData(...)" function for examples of RAPID symbols in raw text format.
+ *
+ * \param client RWS client
+ * \param resource specifies the RAPID task, module, and symbol name for the RAPID resource.
+ *
+ * \return String containing the data.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+std::string getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource);
 
-    /**
-     * \brief A function for setting the data of a RAPID symbol (based on the provided struct representing the RAPID data).
-     *
-     * \param client RWS client
-     * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
-     * \param data for the RAPID symbol's new data.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const RAPIDSymbolDataAbstract& data);
+/**
+ * \brief A function for setting the data of a RAPID symbol (based on the provided struct representing the RAPID data).
+ *
+ * \param client RWS client
+ * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
+ * \param data for the RAPID symbol's new data.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const RAPIDSymbolDataAbstract& data);
 
-    /**
-     * \brief A function for setting the data of a RAPID symbol.
-     *
-     * \param client RWS client
-     * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
-     * \param data the RAPID symbol's new data.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const std::string& data);
+/**
+ * \brief A function for setting the data of a RAPID symbol.
+ *
+ * \param client RWS client
+ * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
+ * \param data the RAPID symbol's new data.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const std::string& data);
 
-    /**
-     * \brief A function for loading a module to the robot controller.
-     *
-     * \param client RWS client
-     * \param task specifying the RAPID task.
-     * \param resource specifying the file's directory and name.
-     * \param replace indicating if the actual module into the controller must be replaced by the new one or not.
-     *
-     * \throw \a std::exception if something goes wrong.
-     */
-    void loadModuleIntoTask(RWSClient& client, const std::string& task, const FileResource& resource, const bool replace = false);
+/**
+ * \brief A function for loading a module to the robot controller.
+ *
+ * \param client RWS client
+ * \param task specifying the RAPID task.
+ * \param resource specifying the file's directory and name.
+ * \param replace indicating if the actual module into the controller must be replaced by the new one or not.
+ *
+ * \throw \a std::exception if something goes wrong.
+ */
+void loadModuleIntoTask(RWSClient& client, const std::string& task, const FileResource& resource,
+                        const bool replace = false);
 
-    /**
-     * \brief A function for unloading a module to the robot controller.
-     *
-     * \param client RWS client
-     * \param task specifying the RAPID task.
-     * \param resource specifying the file's directory and name.
-     *
-     * \throw \a std::exception if something goes wrong.
-     */
-    void unloadModuleFromTask(RWSClient& client, const std::string& task, const FileResource& resource);
-}
+/**
+ * \brief A function for unloading a module to the robot controller.
+ *
+ * \param client RWS client
+ * \param task specifying the RAPID task.
+ * \param resource specifying the file's directory and name.
+ *
+ * \throw \a std::exception if something goes wrong.
+ */
+void unloadModuleFromTask(RWSClient& client, const std::string& task, const FileResource& resource);
+}  // namespace abb::rws::v1_0::rw::rapid

--- a/include/abb_librws/v1_0/rws.h
+++ b/include/abb_librws/v1_0/rws.h
@@ -5,494 +5,491 @@
 
 #include <iosfwd>
 
-
-namespace abb :: rws :: v1_0
+namespace abb ::rws ::v1_0
+{
+/**
+ * \brief XML attributes specifying names with corresponding values.
+ */
+struct XMLAttributes
 {
   /**
-   * \brief XML attributes specifying names with corresponding values.
+   * \brief Class & active type.
    */
-  struct XMLAttributes
-  {
-    /**
-     * \brief Class & active type.
-     */
-    static const XMLAttribute CLASS_ACTIVE;
-
-    /**
-     * \brief Class & cfg-dt-instance-li.
-     */
-    static const XMLAttribute CLASS_CFG_DT_INSTANCE_LI;
-
-    /**
-     * \brief Class & cfg-ia-t-li.
-     */
-    static const XMLAttribute CLASS_CFG_IA_T_LI;
-
-    /**
-     * \brief Class & controller type.
-     */
-    static const XMLAttribute CLASS_CTRL_TYPE;
-
-    /**
-     * \brief Class & controller execution state.
-     */
-    static const XMLAttribute CLASS_CTRLEXECSTATE;
-
-    /**
-     * \brief Class & controller state.
-     */
-    static const XMLAttribute CLASS_CTRLSTATE;
-
-    /**
-     * \brief Class & data type.
-     */
-    static const XMLAttribute CLASS_DATTYP;
-
-    /**
-     * \brief Class & excstate type.
-     */
-    static const XMLAttribute CLASS_EXCSTATE;
-
-    /**
-     * \brief Class & ios-signal.
-     */
-    static const XMLAttribute CLASS_IOS_SIGNAL;
-
-    /**
-     * \brief Class & lvalue.
-     */
-    static const XMLAttribute CLASS_LVALUE;
-
-    /**
-     * \brief Class & motiontask.
-     */
-    static const XMLAttribute CLASS_MOTIONTASK;
-
-    /**
-     * \brief Class & name.
-     */
-    static const XMLAttribute CLASS_NAME;
-
-    /**
-     * \brief Class & operation mode.
-     */
-    static const XMLAttribute CLASS_OPMODE;
-
-    /**
-     * \brief Class & rap-module-info-li.
-     */
-    static const XMLAttribute CLASS_RAP_MODULE_INFO_LI;
-
-    /**
-     * \brief Class & rap-task-li.
-     */
-    static const XMLAttribute CLASS_RAP_TASK_LI;
-
-    /**
-     * \brief Class & RobotWare version name.
-     */
-    static const XMLAttribute CLASS_RW_VERSION_NAME;
-
-    /**
-     * \brief Class & state.
-     */
-    static const XMLAttribute CLASS_STATE;
-
-    /**
-     * \brief Class & sys-option-li.
-     */
-    static const XMLAttribute CLASS_SYS_OPTION_LI;
-
-    /**
-     * \brief Class & sys-system-li.
-     */
-    static const XMLAttribute CLASS_SYS_SYSTEM_LI;
-
-    /**
-     * \brief Class & type.
-     */
-    static const XMLAttribute CLASS_TYPE;
-
-    /**
-     * \brief Class & value.
-     */
-    static const XMLAttribute CLASS_VALUE;
-
-    /**
-     * \brief Class & option.
-     */
-    static const XMLAttribute CLASS_OPTION;
-  };
+  static const XMLAttribute CLASS_ACTIVE;
 
   /**
-   * \brief Identifiers in different RWS messages. E.g. XML attribute names/values.
+   * \brief Class & cfg-dt-instance-li.
    */
-  struct ABB_LIBRWS_EXPORT Identifiers
-  {
-    /**
-     * \brief Active type.
-     */
-    static const std::string ACTIVE;
-
-    /**
-     * \brief Configuration motion domain type: arm.
-     */
-    static const std::string ARM;
-
-    /**
-     * \brief XML attribute name: class.
-     */
-    static const std::string CLASS;
-
-    /**
-     * \brief Configuration instance list item.
-     */
-    static const std::string CFG_DT_INSTANCE_LI;
-
-    /**
-     * \brief Configuration list item.
-     */
-    static const std::string CFG_IA_T_LI;
-
-    /**
-     * \brief Controller type.
-     */
-    static const std::string CTRL_TYPE;
-
-    /**
-     * \brief Controller execution state.
-     */
-    static const std::string CTRLEXECSTATE;
-
-    /**
-     * \brief Controller state.
-     */
-    static const std::string CTRLSTATE;
-
-    /**
-     * \brief Data type.
-     */
-    static const std::string DATTYP;
-
-    /**
-     * \brief Execution state type.
-     */
-    static const std::string EXCSTATE;
-
-    /**
-     * \brief Home directory.
-     */
-    static const std::string HOME_DIRECTORY;
-
-    /**
-     * \brief IO signal.
-     */
-    static const std::string IOS_SIGNAL;
-
-    /**
-     * \brief Mechanical unit.
-     */
-    static const std::string MECHANICAL_UNIT;
-
-    /**
-     * \brief Mechanical unit group.
-     */
-    static const std::string MECHANICAL_UNIT_GROUP;
-
-    /**
-     * \brief Motion topic in the system configurations (abbreviated as moc).
-     */
-    static const std::string MOC;
-
-    /**
-     * \brief Module name.
-     */
-    static const std::string MODULE;
-
-    /**
-     * \brief Module path.
-     */
-    static const std::string MODULEPATH;
-
-    /**
-     * \brief Motion task.
-     */
-    static const std::string MOTIONTASK;
-
-    /**
-     * \brief Name.
-     */
-    static const std::string NAME;
-
-    /**
-     * \brief Lvalue.
-     */
-    static const std::string LVALUE;
-
-    /**
-     * \brief Opmode.
-     */
-    static const std::string OPMODE;
-
-    /**
-     * \brief Options present on the controller.
-     */
-    static const std::string PRESENT_OPTIONS;
-
-    /**
-     * \brief RAPID module info list item.
-     */
-    static const std::string RAP_MODULE_INFO_LI;
-
-    /**
-     * \brief RAPID task list item.
-     */
-    static const std::string RAP_TASK_LI;
-
-    /**
-     * \brief Robot.
-     */
-    static const std::string ROBOT;
-
-    /**
-     * \brief RobotWare version name.
-     */
-    static const std::string RW_VERSION_NAME;
-
-    /**
-     * \brief Single.
-     */
-    static const std::string SINGLE;
-
-    /**
-     * \brief State.
-     */
-    static const std::string STATE;
-
-    /**
-     * \brief Controller topic in the system configurations (abbreviated as sys).
-     */
-    static const std::string SYS;
-
-    /**
-     * \brief Sys option list item.
-     */
-    static const std::string SYS_OPTION_LI;
-
-    /**
-     * \brief Sys system list item.
-     */
-    static const std::string SYS_SYSTEM_LI;
-
-    /**
-     * \brief Title.
-     */
-    static const std::string TITLE;
-
-    /**
-     * \brief Type.
-     */
-    static const std::string TYPE;
-
-    /**
-     * \brief Value.
-     */
-    static const std::string VALUE;
-
-    /**
-     * \brief Option.
-     */
-    static const std::string OPTION;
-  };
+  static const XMLAttribute CLASS_CFG_DT_INSTANCE_LI;
 
   /**
-   * \brief RWS queries.
+   * \brief Class & cfg-ia-t-li.
    */
-  struct ABB_LIBRWS_EXPORT Queries
-  {
-    /**
-     * \brief Load module action query.
-     */
-    static const std::string ACTION_LOAD_MODULE;
-
-    /**
-     * \brief Release action query.
-     */
-    static const std::string ACTION_RELEASE;
-
-    /**
-     * \brief Request action query.
-     */
-    static const std::string ACTION_REQUEST;
-
-    /**
-     * \brief Reset program pointer action query.
-     */
-    static const std::string ACTION_RESETPP;
-
-    /**
-     * \brief Set action query.
-     */
-    static const std::string ACTION_SET;
-
-    /**
-     * \brief Set controller state action query.
-     */
-    static const std::string ACTION_SETCTRLSTATE;
-
-    /**
-     * \brief Set locale.
-     */
-    static const std::string ACTION_SET_LOCALE;
-
-    /**
-     * \brief Start action query.
-     */
-    static const std::string ACTION_START;
-
-    /**
-     * \brief Stop action query.
-     */
-    static const std::string ACTION_STOP;
-
-    /**
-     * \brief Unload module action query.
-     */
-    static const std::string ACTION_UNLOAD_MODULE;
-
-    /**
-     * \brief Task query.
-     */
-    static const std::string TASK;
-  };
+  static const XMLAttribute CLASS_CFG_IA_T_LI;
 
   /**
-   * \brief RWS resources and queries.
+   * \brief Class & controller type.
    */
-  struct ABB_LIBRWS_EXPORT Resources
-  {
-    /**
-     * \brief Instances.
-     */
-    static const std::string INSTANCES;
-
-    /**
-     * \brief Jointtarget.
-     */
-    static const std::string JOINTTARGET;
-
-    /**
-     * \brief Logout.
-     */
-    static const std::string LOGOUT;
-
-    /**
-     * \brief Robtarget.
-     */
-    static const std::string ROBTARGET;
-
-    /**
-     * \brief Configurations.
-     */
-    static const std::string RW_CFG;
-
-    /**
-     * \brief Signals.
-     */
-    static const std::string RW_IOSYSTEM_SIGNALS;
-
-    /**
-     * \brief Mastership.
-     */
-    static const std::string RW_MASTERSHIP;
-
-    /**
-     * \brief Mechanical units.
-     */
-    static const std::string RW_MOTIONSYSTEM_MECHUNITS;
-
-    /**
-     * \brief Panel controller state.
-     */
-    static const std::string RW_PANEL_CTRLSTATE;
-
-    /**
-     * \brief Panel operation mode.
-     */
-    static const std::string RW_PANEL_OPMODE;
-
-    /**
-     * \brief RAPID execution.
-     */
-    static const std::string RW_RAPID_EXECUTION;
-
-    /**
-     * \brief RAPID modules.
-     */
-    static const std::string RW_RAPID_MODULES;
-
-    /**
-     * \brief RAPID symbol data.
-     */
-    static const std::string RW_RAPID_SYMBOL_DATA_RAPID;
-
-    /**
-     * \brief RAPID symbol properties.
-     */
-    static const std::string RW_RAPID_SYMBOL_PROPERTIES_RAPID;
-
-    /**
-     * \brief RAPID tasks.
-     */
-    static const std::string RW_RAPID_TASKS;
-
-    /**
-     * \brief RobotWare system.
-     */
-    static const std::string RW_SYSTEM;
-  };
+  static const XMLAttribute CLASS_CTRL_TYPE;
 
   /**
-   * \brief RWS services.
+   * \brief Class & controller execution state.
    */
-  struct ABB_LIBRWS_EXPORT Services
-  {
-    /**
-     * \brief Controller service.
-     */
-    static const std::string CTRL;
+  static const XMLAttribute CLASS_CTRLEXECSTATE;
 
-    /**
-     * \brief Fileservice.
-     */
-    static const std::string FILESERVICE;
+  /**
+   * \brief Class & controller state.
+   */
+  static const XMLAttribute CLASS_CTRLSTATE;
 
-    /**
-     * \brief RobotWare service.
-     */
-    static const std::string RW;
+  /**
+   * \brief Class & data type.
+   */
+  static const XMLAttribute CLASS_DATTYP;
 
-    /**
-     * \brief Subscription service.
-     */
-    static const std::string SUBSCRIPTION;
+  /**
+   * \brief Class & excstate type.
+   */
+  static const XMLAttribute CLASS_EXCSTATE;
 
-    /**
-     * \brief User service.
-     */
-    static const std::string USERS;
-  };
+  /**
+   * \brief Class & ios-signal.
+   */
+  static const XMLAttribute CLASS_IOS_SIGNAL;
 
+  /**
+   * \brief Class & lvalue.
+   */
+  static const XMLAttribute CLASS_LVALUE;
 
-  /// @brief RWS 1.0 mastership domains.
-  ///
-  enum class MastershipDomain
-  {
-    cfg,
-    motion,
-    rapid
-  };
+  /**
+   * \brief Class & motiontask.
+   */
+  static const XMLAttribute CLASS_MOTIONTASK;
 
+  /**
+   * \brief Class & name.
+   */
+  static const XMLAttribute CLASS_NAME;
 
-  std::ostream& operator<<(std::ostream& os, MastershipDomain domain);
-}
+  /**
+   * \brief Class & operation mode.
+   */
+  static const XMLAttribute CLASS_OPMODE;
+
+  /**
+   * \brief Class & rap-module-info-li.
+   */
+  static const XMLAttribute CLASS_RAP_MODULE_INFO_LI;
+
+  /**
+   * \brief Class & rap-task-li.
+   */
+  static const XMLAttribute CLASS_RAP_TASK_LI;
+
+  /**
+   * \brief Class & RobotWare version name.
+   */
+  static const XMLAttribute CLASS_RW_VERSION_NAME;
+
+  /**
+   * \brief Class & state.
+   */
+  static const XMLAttribute CLASS_STATE;
+
+  /**
+   * \brief Class & sys-option-li.
+   */
+  static const XMLAttribute CLASS_SYS_OPTION_LI;
+
+  /**
+   * \brief Class & sys-system-li.
+   */
+  static const XMLAttribute CLASS_SYS_SYSTEM_LI;
+
+  /**
+   * \brief Class & type.
+   */
+  static const XMLAttribute CLASS_TYPE;
+
+  /**
+   * \brief Class & value.
+   */
+  static const XMLAttribute CLASS_VALUE;
+
+  /**
+   * \brief Class & option.
+   */
+  static const XMLAttribute CLASS_OPTION;
+};
+
+/**
+ * \brief Identifiers in different RWS messages. E.g. XML attribute names/values.
+ */
+struct ABB_LIBRWS_EXPORT Identifiers
+{
+  /**
+   * \brief Active type.
+   */
+  static const std::string ACTIVE;
+
+  /**
+   * \brief Configuration motion domain type: arm.
+   */
+  static const std::string ARM;
+
+  /**
+   * \brief XML attribute name: class.
+   */
+  static const std::string CLASS;
+
+  /**
+   * \brief Configuration instance list item.
+   */
+  static const std::string CFG_DT_INSTANCE_LI;
+
+  /**
+   * \brief Configuration list item.
+   */
+  static const std::string CFG_IA_T_LI;
+
+  /**
+   * \brief Controller type.
+   */
+  static const std::string CTRL_TYPE;
+
+  /**
+   * \brief Controller execution state.
+   */
+  static const std::string CTRLEXECSTATE;
+
+  /**
+   * \brief Controller state.
+   */
+  static const std::string CTRLSTATE;
+
+  /**
+   * \brief Data type.
+   */
+  static const std::string DATTYP;
+
+  /**
+   * \brief Execution state type.
+   */
+  static const std::string EXCSTATE;
+
+  /**
+   * \brief Home directory.
+   */
+  static const std::string HOME_DIRECTORY;
+
+  /**
+   * \brief IO signal.
+   */
+  static const std::string IOS_SIGNAL;
+
+  /**
+   * \brief Mechanical unit.
+   */
+  static const std::string MECHANICAL_UNIT;
+
+  /**
+   * \brief Mechanical unit group.
+   */
+  static const std::string MECHANICAL_UNIT_GROUP;
+
+  /**
+   * \brief Motion topic in the system configurations (abbreviated as moc).
+   */
+  static const std::string MOC;
+
+  /**
+   * \brief Module name.
+   */
+  static const std::string MODULE;
+
+  /**
+   * \brief Module path.
+   */
+  static const std::string MODULEPATH;
+
+  /**
+   * \brief Motion task.
+   */
+  static const std::string MOTIONTASK;
+
+  /**
+   * \brief Name.
+   */
+  static const std::string NAME;
+
+  /**
+   * \brief Lvalue.
+   */
+  static const std::string LVALUE;
+
+  /**
+   * \brief Opmode.
+   */
+  static const std::string OPMODE;
+
+  /**
+   * \brief Options present on the controller.
+   */
+  static const std::string PRESENT_OPTIONS;
+
+  /**
+   * \brief RAPID module info list item.
+   */
+  static const std::string RAP_MODULE_INFO_LI;
+
+  /**
+   * \brief RAPID task list item.
+   */
+  static const std::string RAP_TASK_LI;
+
+  /**
+   * \brief Robot.
+   */
+  static const std::string ROBOT;
+
+  /**
+   * \brief RobotWare version name.
+   */
+  static const std::string RW_VERSION_NAME;
+
+  /**
+   * \brief Single.
+   */
+  static const std::string SINGLE;
+
+  /**
+   * \brief State.
+   */
+  static const std::string STATE;
+
+  /**
+   * \brief Controller topic in the system configurations (abbreviated as sys).
+   */
+  static const std::string SYS;
+
+  /**
+   * \brief Sys option list item.
+   */
+  static const std::string SYS_OPTION_LI;
+
+  /**
+   * \brief Sys system list item.
+   */
+  static const std::string SYS_SYSTEM_LI;
+
+  /**
+   * \brief Title.
+   */
+  static const std::string TITLE;
+
+  /**
+   * \brief Type.
+   */
+  static const std::string TYPE;
+
+  /**
+   * \brief Value.
+   */
+  static const std::string VALUE;
+
+  /**
+   * \brief Option.
+   */
+  static const std::string OPTION;
+};
+
+/**
+ * \brief RWS queries.
+ */
+struct ABB_LIBRWS_EXPORT Queries
+{
+  /**
+   * \brief Load module action query.
+   */
+  static const std::string ACTION_LOAD_MODULE;
+
+  /**
+   * \brief Release action query.
+   */
+  static const std::string ACTION_RELEASE;
+
+  /**
+   * \brief Request action query.
+   */
+  static const std::string ACTION_REQUEST;
+
+  /**
+   * \brief Reset program pointer action query.
+   */
+  static const std::string ACTION_RESETPP;
+
+  /**
+   * \brief Set action query.
+   */
+  static const std::string ACTION_SET;
+
+  /**
+   * \brief Set controller state action query.
+   */
+  static const std::string ACTION_SETCTRLSTATE;
+
+  /**
+   * \brief Set locale.
+   */
+  static const std::string ACTION_SET_LOCALE;
+
+  /**
+   * \brief Start action query.
+   */
+  static const std::string ACTION_START;
+
+  /**
+   * \brief Stop action query.
+   */
+  static const std::string ACTION_STOP;
+
+  /**
+   * \brief Unload module action query.
+   */
+  static const std::string ACTION_UNLOAD_MODULE;
+
+  /**
+   * \brief Task query.
+   */
+  static const std::string TASK;
+};
+
+/**
+ * \brief RWS resources and queries.
+ */
+struct ABB_LIBRWS_EXPORT Resources
+{
+  /**
+   * \brief Instances.
+   */
+  static const std::string INSTANCES;
+
+  /**
+   * \brief Jointtarget.
+   */
+  static const std::string JOINTTARGET;
+
+  /**
+   * \brief Logout.
+   */
+  static const std::string LOGOUT;
+
+  /**
+   * \brief Robtarget.
+   */
+  static const std::string ROBTARGET;
+
+  /**
+   * \brief Configurations.
+   */
+  static const std::string RW_CFG;
+
+  /**
+   * \brief Signals.
+   */
+  static const std::string RW_IOSYSTEM_SIGNALS;
+
+  /**
+   * \brief Mastership.
+   */
+  static const std::string RW_MASTERSHIP;
+
+  /**
+   * \brief Mechanical units.
+   */
+  static const std::string RW_MOTIONSYSTEM_MECHUNITS;
+
+  /**
+   * \brief Panel controller state.
+   */
+  static const std::string RW_PANEL_CTRLSTATE;
+
+  /**
+   * \brief Panel operation mode.
+   */
+  static const std::string RW_PANEL_OPMODE;
+
+  /**
+   * \brief RAPID execution.
+   */
+  static const std::string RW_RAPID_EXECUTION;
+
+  /**
+   * \brief RAPID modules.
+   */
+  static const std::string RW_RAPID_MODULES;
+
+  /**
+   * \brief RAPID symbol data.
+   */
+  static const std::string RW_RAPID_SYMBOL_DATA_RAPID;
+
+  /**
+   * \brief RAPID symbol properties.
+   */
+  static const std::string RW_RAPID_SYMBOL_PROPERTIES_RAPID;
+
+  /**
+   * \brief RAPID tasks.
+   */
+  static const std::string RW_RAPID_TASKS;
+
+  /**
+   * \brief RobotWare system.
+   */
+  static const std::string RW_SYSTEM;
+};
+
+/**
+ * \brief RWS services.
+ */
+struct ABB_LIBRWS_EXPORT Services
+{
+  /**
+   * \brief Controller service.
+   */
+  static const std::string CTRL;
+
+  /**
+   * \brief Fileservice.
+   */
+  static const std::string FILESERVICE;
+
+  /**
+   * \brief RobotWare service.
+   */
+  static const std::string RW;
+
+  /**
+   * \brief Subscription service.
+   */
+  static const std::string SUBSCRIPTION;
+
+  /**
+   * \brief User service.
+   */
+  static const std::string USERS;
+};
+
+/// @brief RWS 1.0 mastership domains.
+///
+enum class MastershipDomain
+{
+  cfg,
+  motion,
+  rapid
+};
+
+std::ostream& operator<<(std::ostream& os, MastershipDomain domain);
+}  // namespace abb::rws::v1_0

--- a/include/abb_librws/v1_0/rws_interface.h
+++ b/include/abb_librws/v1_0/rws_interface.h
@@ -48,8 +48,7 @@
 #include <chrono>
 #include <cstdint>
 
-
-namespace abb :: rws :: v1_0
+namespace abb ::rws ::v1_0
 {
 /**
  * \brief User-friendly interface to Robot Web Services (RWS) 1.0.
@@ -155,14 +154,12 @@ public:
    */
   ABB_LIBRWS_DEPRECATED std::vector<RobotWareOptionInfo> getPresentRobotWareOptions();
 
-
   /// @brief Get value of a digital signal
   ///
   /// @param signal_name Name of the signal
   /// @return Value of the requested digital signal
   ///
   bool getDigitalSignal(std::string const& signal_name);
-
 
   /// @brief Get value of an analog signal
   ///
@@ -171,7 +168,6 @@ public:
   ///
   float getAnalogSignal(std::string const& signal_name);
 
-
   /// @brief Get value of a group signal
   ///
   /// @param signal_name Name of the signal
@@ -179,14 +175,12 @@ public:
   ///
   std::uint32_t getGroupSignal(std::string const& signal_name);
 
-
   /**
    * \brief Get values of all IO signals.
    *
    * \return Mapping from IO signal names to values.
    */
   rw::io::IOSignalInfo getIOSignals();
-
 
   /**
    * \brief A method for retrieving static information about a mechanical unit.
@@ -233,10 +227,8 @@ public:
    *
    * \return robtarget data.
    */
-  RobTarget getMechanicalUnitRobTarget(const std::string& mechunit,
-                                  Coordinate coordinate = Coordinate::ACTIVE,
-                                  const std::string& tool = "",
-                                  const std::string& wobj = "");
+  RobTarget getMechanicalUnitRobTarget(const std::string& mechunit, Coordinate coordinate = Coordinate::ACTIVE,
+                                       const std::string& tool = "", const std::string& wobj = "");
 
   /**
    * \brief A method for retrieving the data of a RAPID symbol in raw text format.
@@ -253,7 +245,6 @@ public:
    */
   std::string getRAPIDSymbolData(const std::string& task, const std::string& module, const std::string& name);
 
-
   /**
    * \brief Retrieves the data of a RAPID symbol (parsed into a struct representing the RAPID data).
    *
@@ -263,7 +254,6 @@ public:
    * \throw \a std::runtime_error if something goes wrong.
    */
   void getRAPIDSymbolData(RAPIDResource const& resource, RAPIDSymbolDataAbstract& data);
-
 
   /**
    * \brief A method for retrieving information about the RAPID modules of a RAPID task defined in the robot controller.
@@ -328,14 +318,12 @@ public:
    */
   bool isRAPIDRunning();
 
-
   /// @brief Set value of a digital signal
   ///
   /// @param signal_name Name of the signal
   /// @param value New value of the signal
   ///
   void setDigitalSignal(std::string const& signal_name, bool value);
-
 
   /// @brief Set value of an analog signal
   ///
@@ -344,14 +332,12 @@ public:
   ///
   void setAnalogSignal(std::string const& signal_name, float value);
 
-
   /// @brief Set value of a group signal
   ///
   /// @param signal_name Name of the signal
   /// @param value New value of the signal
   ///
   void setGroupSignal(std::string const& signal_name, std::uint32_t value);
-
 
   /**
    * \brief A method for setting the data of a RAPID symbol via raw text format.
@@ -378,11 +364,8 @@ public:
    *
    * \throw \a std::runtime_error if something goes wrong.
    */
-  void setRAPIDSymbolData(const std::string& task,
-                          const std::string& module,
-                          const std::string& name,
+  void setRAPIDSymbolData(const std::string& task, const std::string& module, const std::string& name,
                           const std::string& data);
-
 
   /**
    * \brief A method for setting the data of a RAPID symbol.
@@ -392,9 +375,7 @@ public:
    *
    * \throw \a std::runtime_error if something goes wrong.
    */
-  void setRAPIDSymbolData(RAPIDResource const& resource,
-                          const RAPIDSymbolDataAbstract& data);
-
+  void setRAPIDSymbolData(RAPIDResource const& resource, const RAPIDSymbolDataAbstract& data);
 
   /**
    * \brief A method for starting RAPID execution in the robot controller.
@@ -558,11 +539,11 @@ public:
    */
   void requestMastership(MastershipDomain domain);
 
-
   /**
    * \brief Release mastership of a given domain.
    *
-   * \param domain domain for which mastership is to be requested. If empty, mastership for all domains will be released.
+   * \param domain domain for which mastership is to be requested. If empty, mastership for all domains will be
+   * released.
    */
   void releaseMastership(MastershipDomain domain);
 
@@ -586,9 +567,8 @@ private:
    *
    * \return The result of the comparison.
    */
-  static bool compareSingleContent(const RWSResult& rws_result,
-                               const XMLAttribute& attribute,
-                               const std::string& compare_string);
+  static bool compareSingleContent(const RWSResult& rws_result, const XMLAttribute& attribute,
+                                   const std::string& compare_string);
 
   /**
    * \brief A method for retrieving the value of an IO signal.
@@ -598,7 +578,6 @@ private:
    * \return std::string containing the IO signal's value (empty if not found).
    */
   std::string getIOSignal(const std::string& iosignal);
-
 
   /**
    * \brief A method for setting the value of an IO signal.
@@ -610,11 +589,10 @@ private:
    */
   void setIOSignal(const std::string& iosignal, const std::string& value);
 
-
   /**
    * \brief The RWS client used to communicate with the robot controller.
    */
   RWSClient& rws_client_;
 };
 
-} // end namespace rws
+}  // namespace abb::rws::v1_0

--- a/include/abb_librws/v2_0/rw/panel.h
+++ b/include/abb_librws/v2_0/rw/panel.h
@@ -7,74 +7,68 @@
 
 #include <string>
 
-
-namespace abb :: rws :: v2_0 :: rw
+namespace abb ::rws ::v2_0 ::rw
 {
-    using namespace rws::rw;
+using namespace rws::rw;
 }
 
-
-namespace abb :: rws :: v2_0 :: rw :: panel
+namespace abb ::rws ::v2_0 ::rw ::panel
 {
-    /**
-     * \brief A function for retrieving the controller state.
-     *
-     * \param client RWS client
-     *
-     * \return RWSResult containing the result.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    ControllerState getControllerState(RWSClient& client);
+/**
+ * \brief A function for retrieving the controller state.
+ *
+ * \param client RWS client
+ *
+ * \return RWSResult containing the result.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+ControllerState getControllerState(RWSClient& client);
 
+/**
+ * \brief Set controller state
+ *
+ * \param client RWS client
+ * \param state new controller state
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+void setControllerState(RWSClient& client, ControllerState state);
 
-    /**
-     * \brief Set controller state
-     *
-     * \param client RWS client
-     * \param state new controller state
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    void setControllerState(RWSClient& client, ControllerState state);
+/**
+ * \brief A function for retrieving the operation mode of the controller.
+ *
+ * \param client RWS client
+ *
+ * \return RWSResult containing the result.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+OperationMode getOperationMode(RWSClient& client);
 
+/**
+ * \brief A function for retrieving the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
+ *
+ * \param client RWS client
+ *
+ * \return RWSResult containing the result.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+unsigned getSpeedRatio(RWSClient& client);
 
-    /**
-     * \brief A function for retrieving the operation mode of the controller.
-     *
-     * \param client RWS client
-     *
-     * \return RWSResult containing the result.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    OperationMode getOperationMode(RWSClient& client);
-
-
-    /**
-     * \brief A function for retrieving the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
-     *
-     * \param client RWS client
-     *
-     * \return RWSResult containing the result.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    unsigned getSpeedRatio(RWSClient& client);
-
-
-    /**
-     * \brief A function for setting the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
-     *
-     * Note: The ratio must be an integer in the range [0, 100] (ie: inclusive).
-     *
-     * \param client RWS client
-     * \param ratio specifying the new ratio.
-     *
-     * \return RWSResult containing the result.
-     *
-     * \throw std::out_of_range if argument is out of range.
-     * \throw \a RWSError if something goes wrong.
-     */
-    void setSpeedRatio(RWSClient& client, unsigned int ratio);
-}
+/**
+ * \brief A function for setting the robot controller's speed ratio for RAPID motions (e.g. MoveJ and MoveL).
+ *
+ * Note: The ratio must be an integer in the range [0, 100] (ie: inclusive).
+ *
+ * \param client RWS client
+ * \param ratio specifying the new ratio.
+ *
+ * \return RWSResult containing the result.
+ *
+ * \throw std::out_of_range if argument is out of range.
+ * \throw \a RWSError if something goes wrong.
+ */
+void setSpeedRatio(RWSClient& client, unsigned int ratio);
+}  // namespace abb::rws::v2_0::rw::panel

--- a/include/abb_librws/v2_0/rw/rapid.h
+++ b/include/abb_librws/v2_0/rw/rapid.h
@@ -7,174 +7,174 @@
 
 #include <string>
 
-
-namespace abb :: rws :: v2_0 :: rw
+namespace abb ::rws ::v2_0 ::rw
 {
-    using namespace rws::rw;
+using namespace rws::rw;
 }
 
-
-namespace abb :: rws :: v2_0 :: rw :: rapid
+namespace abb ::rws ::v2_0 ::rw ::rapid
 {
-    /**
-     * \brief A function for retrieving the execution state of RAPID.
-     *
-     * https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_get_page.html
-     *
-     * \param client RWS client
-     *
-     * \return Current RAPID execution state.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    RAPIDExecutionInfo getRAPIDExecution(RWSClient& client);
+/**
+ * \brief A function for retrieving the execution state of RAPID.
+ *
+ * https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_get_page.html
+ *
+ * \param client RWS client
+ *
+ * \return Current RAPID execution state.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+RAPIDExecutionInfo getRAPIDExecution(RWSClient& client);
 
-    /**
-     * \brief A function for starting RAPID execution in the robot controller.
-     *
-     * https://developercenter.robotstudio.com/api/RWS?urls.primaryName=RAPID%20Service
-     *
-     * \param client RWS client
-     * \param mastership {implicit | explicit} by default mastership is explicit
-     *
-     * There can be a delay between the function returns and when the RAPID program enters the "running" state.
-     *
-     * \throw \a std::runtime_error if something goes wrong.
-     */
-    void startRAPIDExecution(RWSClient& client, Mastership const& mastership = Mastership::Explicit);
+/**
+ * \brief A function for starting RAPID execution in the robot controller.
+ *
+ * https://developercenter.robotstudio.com/api/RWS?urls.primaryName=RAPID%20Service
+ *
+ * \param client RWS client
+ * \param mastership {implicit | explicit} by default mastership is explicit
+ *
+ * There can be a delay between the function returns and when the RAPID program enters the "running" state.
+ *
+ * \throw \a std::runtime_error if something goes wrong.
+ */
+void startRAPIDExecution(RWSClient& client, Mastership const& mastership = Mastership::Explicit);
 
-    /**
-     * \brief A function for stopping RAPID execution in the robot controller.
-     *
-     * https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_stop_page.html
-     *
-     * There can be a delay between the function returns and when the RAPID program enters the "stopped" state.
-     *
-     * \param client RWS client
-     * \param stopmode stop mode
-     * \param usetsp which tasks to stop (?)
-     *
-     * \throw \a std::runtime_error if something goes wrong.
-     */
-    void stopRAPIDExecution(RWSClient& client, StopMode stopmode = StopMode::stop, UseTsp usetsp = UseTsp::normal);
+/**
+ * \brief A function for stopping RAPID execution in the robot controller.
+ *
+ * https://developercenter.robotstudio.com/api/rwsApi/rapid_execution_stop_page.html
+ *
+ * There can be a delay between the function returns and when the RAPID program enters the "stopped" state.
+ *
+ * \param client RWS client
+ * \param stopmode stop mode
+ * \param usetsp which tasks to stop (?)
+ *
+ * \throw \a std::runtime_error if something goes wrong.
+ */
+void stopRAPIDExecution(RWSClient& client, StopMode stopmode = StopMode::stop, UseTsp usetsp = UseTsp::normal);
 
-    /**
-     * \brief A function for reseting the RAPID program pointer in the robot controller.
-     *
-     * https://developercenter.robotstudio.com/api/RWS?urls.primaryName=RAPID%20Service
-     *
-     * \param client RWS client
-     * \param mastership {implicit | explicit} by default mastership is explicit
-     *
-     * \throw \a std::runtime_error if something goes wrong.
-     */
-    void resetRAPIDProgramPointer(RWSClient& client, Mastership const& mastership = Mastership::Explicit);
+/**
+ * \brief A function for reseting the RAPID program pointer in the robot controller.
+ *
+ * https://developercenter.robotstudio.com/api/RWS?urls.primaryName=RAPID%20Service
+ *
+ * \param client RWS client
+ * \param mastership {implicit | explicit} by default mastership is explicit
+ *
+ * \throw \a std::runtime_error if something goes wrong.
+ */
+void resetRAPIDProgramPointer(RWSClient& client, Mastership const& mastership = Mastership::Explicit);
 
-    /**
-     * \brief A function for retrieving information about the RAPID modules of a RAPID task defined in the robot controller.
-     *
-     * \param client RWS client
-     *
-     * \return \a std::vector<RAPIDModuleInfo> containing the RAPID modules information.
-     *
-     * \throw \a std::runtime_error if something goes wrong.
-     */
-    std::vector<RAPIDModuleInfo> getRAPIDModulesInfo(RWSClient& client, const std::string& task);
+/**
+ * \brief A function for retrieving information about the RAPID modules of a RAPID task defined in the robot controller.
+ *
+ * \param client RWS client
+ *
+ * \return \a std::vector<RAPIDModuleInfo> containing the RAPID modules information.
+ *
+ * \throw \a std::runtime_error if something goes wrong.
+ */
+std::vector<RAPIDModuleInfo> getRAPIDModulesInfo(RWSClient& client, const std::string& task);
 
-    /**
-     * \brief A function for retrieving information about the RAPID tasks defined in the robot controller.
-     *
-     * \param client RWS client
-     *
-     * \return \a std::vector<RAPIDTaskInfo> containing the RAPID tasks information.
-     *
-     * \throw \a std::runtime_error if something goes wrong.
-     */
-    std::vector<RAPIDTaskInfo> getRAPIDTasks(RWSClient& client);
+/**
+ * \brief A function for retrieving information about the RAPID tasks defined in the robot controller.
+ *
+ * \param client RWS client
+ *
+ * \return \a std::vector<RAPIDTaskInfo> containing the RAPID tasks information.
+ *
+ * \throw \a std::runtime_error if something goes wrong.
+ */
+std::vector<RAPIDTaskInfo> getRAPIDTasks(RWSClient& client);
 
-    /**
-     * \brief A function for retrieving the data of a RAPID symbol.
-     *
-     * \param client RWS client
-     * \param resource specifies the RAPID task, module, and symbol name for the RAPID resource.
-     * \param data variable for receiving the symbol value.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    void getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource, RAPIDSymbolDataAbstract& data);
+/**
+ * \brief A function for retrieving the data of a RAPID symbol.
+ *
+ * \param client RWS client
+ * \param resource specifies the RAPID task, module, and symbol name for the RAPID resource.
+ * \param data variable for receiving the symbol value.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+void getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource, RAPIDSymbolDataAbstract& data);
 
-    /**
-     * \brief A function for retrieving the data of a RAPID symbol in raw text format.
-     *
-     * See the corresponding "setRAPIDSymbolData(...)" function for examples of RAPID symbols in raw text format.
-     *
-     * \param client RWS client
-     * \param resource specifies the RAPID task, module, and symbol name for the RAPID resource.
-     *
-     * \return String containing the data.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    std::string getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource);
+/**
+ * \brief A function for retrieving the data of a RAPID symbol in raw text format.
+ *
+ * See the corresponding "setRAPIDSymbolData(...)" function for examples of RAPID symbols in raw text format.
+ *
+ * \param client RWS client
+ * \param resource specifies the RAPID task, module, and symbol name for the RAPID resource.
+ *
+ * \return String containing the data.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+std::string getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource);
 
-    /**
-     * \brief A function for setting the data of a RAPID symbol (based on the provided struct representing the RAPID data).
-     *
-     * https://developercenter.robotstudio.com/api/RWS?urls.primaryName=RAPID%20Service
-     *
-     * \param client RWS client
-     * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
-     * \param data for the RAPID symbol's new data.
-     * \param initval true -- set the initial value, false -- set the current value.
-     * \param log changes will be updated in elog (not applicable in updating initial value)
-     * \param mastership {implicit | explicit} by default mastership is explicit
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const RAPIDSymbolDataAbstract& data,
-        bool initval = false, bool log = false, Mastership const& mastership = Mastership::Explicit);
+/**
+ * \brief A function for setting the data of a RAPID symbol (based on the provided struct representing the RAPID data).
+ *
+ * https://developercenter.robotstudio.com/api/RWS?urls.primaryName=RAPID%20Service
+ *
+ * \param client RWS client
+ * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
+ * \param data for the RAPID symbol's new data.
+ * \param initval true -- set the initial value, false -- set the current value.
+ * \param log changes will be updated in elog (not applicable in updating initial value)
+ * \param mastership {implicit | explicit} by default mastership is explicit
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const RAPIDSymbolDataAbstract& data,
+                        bool initval = false, bool log = false, Mastership const& mastership = Mastership::Explicit);
 
-    /**
-     * \brief A function for setting the data of a RAPID symbol.
-     *
-     * \param client RWS client
-     * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
-     * \param data the RAPID symbol's new data.
-     * \param initval true -- set the initial value, false -- set the current value.
-     * \param log changes will be updated in elog (not applicable in updating initial value)
-     * \param mastership {implicit | explicit} by default mastership is explicit
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const std::string& data,
-        bool initval = false, bool log = false, Mastership const& mastership = Mastership::Explicit);
+/**
+ * \brief A function for setting the data of a RAPID symbol.
+ *
+ * \param client RWS client
+ * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
+ * \param data the RAPID symbol's new data.
+ * \param initval true -- set the initial value, false -- set the current value.
+ * \param log changes will be updated in elog (not applicable in updating initial value)
+ * \param mastership {implicit | explicit} by default mastership is explicit
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const std::string& data, bool initval = false,
+                        bool log = false, Mastership const& mastership = Mastership::Explicit);
 
-    /**
-     * \brief A function for loading a module to the robot controller.
-     *
-     * https://developercenter.robotstudio.com/api/RWS?urls.primaryName=RAPID%20Service
-     *
-     * \param client RWS client
-     * \param task specifying the RAPID task.
-     * \param resource specifying the file's directory and name.
-     * \param replace indicating if the actual module into the controller must be replaced by the new one or not.
-     * \param mastership {implicit | explicit} by default mastership is explicit
-     *
-     * \throw \a std::exception if something goes wrong.
-     */
-    void loadModuleIntoTask(RWSClient& client, const std::string& task, const FileResource& resource, const bool replace = false, Mastership const& mastership = Mastership::Explicit);
+/**
+ * \brief A function for loading a module to the robot controller.
+ *
+ * https://developercenter.robotstudio.com/api/RWS?urls.primaryName=RAPID%20Service
+ *
+ * \param client RWS client
+ * \param task specifying the RAPID task.
+ * \param resource specifying the file's directory and name.
+ * \param replace indicating if the actual module into the controller must be replaced by the new one or not.
+ * \param mastership {implicit | explicit} by default mastership is explicit
+ *
+ * \throw \a std::exception if something goes wrong.
+ */
+void loadModuleIntoTask(RWSClient& client, const std::string& task, const FileResource& resource,
+                        const bool replace = false, Mastership const& mastership = Mastership::Explicit);
 
-    /**
-     * \brief A function for unloading a module to the robot controller.
-     *
-     * https://developercenter.robotstudio.com/api/RWS?urls.primaryName=RAPID%20Service
-     *
-     * \param client RWS client
-     * \param task specifying the RAPID task.
-     * \param module_name name of the module to unload.
-     * \param mastership {implicit | explicit} by default mastership is explicit
-     *
-     * \throw \a std::exception if something goes wrong.
-     */
-    void unloadModuleFromTask(RWSClient& client, const std::string& task, const std::string& module_name, Mastership const& mastership = Mastership::Explicit);
-}
+/**
+ * \brief A function for unloading a module to the robot controller.
+ *
+ * https://developercenter.robotstudio.com/api/RWS?urls.primaryName=RAPID%20Service
+ *
+ * \param client RWS client
+ * \param task specifying the RAPID task.
+ * \param module_name name of the module to unload.
+ * \param mastership {implicit | explicit} by default mastership is explicit
+ *
+ * \throw \a std::exception if something goes wrong.
+ */
+void unloadModuleFromTask(RWSClient& client, const std::string& task, const std::string& module_name,
+                          Mastership const& mastership = Mastership::Explicit);
+}  // namespace abb::rws::v2_0::rw::rapid

--- a/include/abb_librws/v2_0/rws.h
+++ b/include/abb_librws/v2_0/rws.h
@@ -5,505 +5,500 @@
 
 #include <iosfwd>
 
-
-namespace abb :: rws :: v2_0
+namespace abb ::rws ::v2_0
+{
+/**
+ * \brief XML attributes specifying names with corresponding values.
+ */
+struct ABB_LIBRWS_EXPORT XMLAttributes
 {
   /**
-   * \brief XML attributes specifying names with corresponding values.
+   * \brief Class & active type.
    */
-  struct ABB_LIBRWS_EXPORT XMLAttributes
-  {
-    /**
-     * \brief Class & active type.
-     */
-    static const XMLAttribute CLASS_ACTIVE;
-
-    /**
-     * \brief Class & cfg-dt-instance-li.
-     */
-    static const XMLAttribute CLASS_CFG_DT_INSTANCE_LI;
-
-    /**
-     * \brief Class & cfg-ia-t-li.
-     */
-    static const XMLAttribute CLASS_CFG_IA_T_LI;
-
-    /**
-     * \brief Class & controller type.
-     */
-    static const XMLAttribute CLASS_CTRL_TYPE;
-
-    /**
-     * \brief Class & controller execution state.
-     */
-    static const XMLAttribute CLASS_CTRLEXECSTATE;
-
-    /**
-     * \brief Class & controller state.
-     */
-    static const XMLAttribute CLASS_CTRLSTATE;
-
-    /**
-     * \brief Class & data type.
-     */
-    static const XMLAttribute CLASS_DATTYP;
-
-    /**
-     * \brief Class & excstate type.
-     */
-    static const XMLAttribute CLASS_EXCSTATE;
-
-    /**
-     * \brief Class & ios-signal.
-     */
-    static const XMLAttribute CLASS_IOS_SIGNAL;
-
-    /**
-     * \brief Class & lvalue.
-     */
-    static const XMLAttribute CLASS_LVALUE;
-
-    /**
-     * \brief Class & motiontask.
-     */
-    static const XMLAttribute CLASS_MOTIONTASK;
-
-    /**
-     * \brief Class & name.
-     */
-    static const XMLAttribute CLASS_NAME;
-
-    /**
-     * \brief Class & operation mode.
-     */
-    static const XMLAttribute CLASS_OPMODE;
-
-    /**
-     * \brief Class & rap-module-info-li.
-     */
-    static const XMLAttribute CLASS_RAP_MODULE_INFO_LI;
-
-    /**
-     * \brief Class & rap-task-li.
-     */
-    static const XMLAttribute CLASS_RAP_TASK_LI;
-
-    /**
-     * \brief Class & RobotWare version name.
-     */
-    static const XMLAttribute CLASS_RW_VERSION_NAME;
-
-    /**
-     * \brief Class & state.
-     */
-    static const XMLAttribute CLASS_STATE;
-
-    /**
-     * \brief Class & sys-option-li.
-     */
-    static const XMLAttribute CLASS_SYS_OPTION_LI;
-
-    /**
-     * \brief Class & sys-system-li.
-     */
-    static const XMLAttribute CLASS_SYS_SYSTEM_LI;
-
-    /**
-     * \brief Class & type.
-     */
-    static const XMLAttribute CLASS_TYPE;
-
-    /**
-     * \brief Class & value.
-     */
-    static const XMLAttribute CLASS_VALUE;
-
-    /**
-     * \brief Class & option.
-     */
-    static const XMLAttribute CLASS_OPTION;
-  };
+  static const XMLAttribute CLASS_ACTIVE;
 
   /**
-   * \brief Identifiers in different RWS messages. E.g. XML attribute names/values.
+   * \brief Class & cfg-dt-instance-li.
    */
-  struct ABB_LIBRWS_EXPORT Identifiers
-  {
-    /**
-     * \brief Active type.
-     */
-    static const std::string ACTIVE;
-
-    /**
-     * \brief Configuration motion domain type: arm.
-     */
-    static const std::string ARM;
-
-    /**
-     * \brief XML attribute name: class.
-     */
-    static const std::string CLASS;
-
-    /**
-     * \brief Configuration instance list item.
-     */
-    static const std::string CFG_DT_INSTANCE_LI;
-
-    /**
-     * \brief Configuration list item.
-     */
-    static const std::string CFG_IA_T_LI;
-
-    /**
-     * \brief Controller type.
-     */
-    static const std::string CTRL_TYPE;
-
-    /**
-     * \brief Controller execution state.
-     */
-    static const std::string CTRLEXECSTATE;
-
-    /**
-     * \brief Controller state.
-     */
-    static const std::string CTRLSTATE;
-
-    /**
-     * \brief Data type.
-     */
-    static const std::string DATTYP;
-
-    /**
-     * \brief Execution state type.
-     */
-    static const std::string EXCSTATE;
-
-    /**
-     * \brief Home directory.
-     */
-    static const std::string HOME_DIRECTORY;
-
-    /**
-     * \brief IO signal.
-     */
-    static const std::string IOS_SIGNAL;
-
-    /**
-     * \brief Mechanical unit.
-     */
-    static const std::string MECHANICAL_UNIT;
-
-    /**
-     * \brief Mechanical unit group.
-     */
-    static const std::string MECHANICAL_UNIT_GROUP;
-
-    /**
-     * \brief Motion topic in the system configurations (abbreviated as moc).
-     */
-    static const std::string MOC;
-
-    /**
-     * \brief Module name.
-     */
-    static const std::string MODULE;
-
-    /**
-     * \brief Module path.
-     */
-    static const std::string MODULEPATH;
-
-    /**
-     * \brief Motion task.
-     */
-    static const std::string MOTIONTASK;
-
-    /**
-     * \brief Name.
-     */
-    static const std::string NAME;
-
-    /**
-     * \brief Lvalue.
-     */
-    static const std::string LVALUE;
-
-    /**
-     * \brief Opmode.
-     */
-    static const std::string OPMODE;
-
-    /**
-     * \brief Options present on the controller.
-     */
-    static const std::string PRESENT_OPTIONS;
-
-    /**
-     * \brief RAPID module info list item.
-     */
-    static const std::string RAP_MODULE_INFO_LI;
-
-    /**
-     * \brief RAPID task list item.
-     */
-    static const std::string RAP_TASK_LI;
-
-    /**
-     * \brief Robot.
-     */
-    static const std::string ROBOT;
-
-    /**
-     * \brief RobotWare version name.
-     */
-    static const std::string RW_VERSION_NAME;
-
-    /**
-     * \brief Single.
-     */
-    static const std::string SINGLE;
-
-    /**
-     * \brief State.
-     */
-    static const std::string STATE;
-
-    /**
-     * \brief Controller topic in the system configurations (abbreviated as sys).
-     */
-    static const std::string SYS;
-
-    /**
-     * \brief Sys option list item.
-     */
-    static const std::string SYS_OPTION_LI;
-
-    /**
-     * \brief Sys system list item.
-     */
-    static const std::string SYS_SYSTEM_LI;
-
-    /**
-     * \brief Title.
-     */
-    static const std::string TITLE;
-
-    /**
-     * \brief Type.
-     */
-    static const std::string TYPE;
-
-    /**
-     * \brief Value.
-     */
-    static const std::string VALUE;
-
-    /**
-     * \brief Option.
-     */
-    static const std::string OPTION;
-  };
+  static const XMLAttribute CLASS_CFG_DT_INSTANCE_LI;
 
   /**
-   * \brief RWS queries.
+   * \brief Class & cfg-ia-t-li.
    */
-  struct ABB_LIBRWS_EXPORT Queries
-  {
-    /**
-     * \brief Load module action query.
-     */
-    static const std::string ACTION_LOAD_MODULE;
-
-    /**
-     * \brief Release action query.
-     */
-    static const std::string ACTION_RELEASE;
-
-    /**
-     * \brief Request action query.
-     */
-    static const std::string ACTION_REQUEST;
-
-    /**
-     * \brief Reset program pointer action query.
-     */
-    static const std::string ACTION_RESETPP;
-
-    /**
-     * \brief Set action query.
-     */
-    static const std::string ACTION_SET;
-
-    /**
-     * \brief Set controller state action query.
-     */
-    static const std::string ACTION_SETCTRLSTATE;
-
-    /**
-     * \brief Set locale.
-     */
-    static const std::string ACTION_SET_LOCALE;
-
-    /**
-     * \brief Start action query.
-     */
-    static const std::string ACTION_START;
-
-    /**
-     * \brief Stop action query.
-     */
-    static const std::string ACTION_STOP;
-
-    /**
-     * \brief Unload module action query.
-     */
-    static const std::string ACTION_UNLOAD_MODULE;
-
-    /**
-     * \brief Task query.
-     */
-    static const std::string TASK;
-  };
+  static const XMLAttribute CLASS_CFG_IA_T_LI;
 
   /**
-   * \brief RWS resources and queries.
+   * \brief Class & controller type.
    */
-  struct ABB_LIBRWS_EXPORT Resources
-  {
-    /**
-     * \brief Instances.
-     */
-    static const std::string INSTANCES;
-
-    /**
-     * \brief Jointtarget.
-     */
-    static const std::string JOINTTARGET;
-
-    /**
-     * \brief Logout.
-     */
-    static const std::string LOGOUT;
-
-    /**
-     * \brief Robtarget.
-     */
-    static const std::string ROBTARGET;
-
-    /**
-     * \brief Configurations.
-     */
-    static const std::string RW_CFG;
-
-    /**
-     * \brief Signals.
-     */
-    static const std::string RW_IOSYSTEM_SIGNALS;
-
-    /**
-     * \brief Mastership.
-     */
-    static const std::string RW_MASTERSHIP;
-
-    /**
-     * \brief Mechanical units.
-     */
-    static const std::string RW_MOTIONSYSTEM_MECHUNITS;
-
-    /**
-     * \brief Panel controller state.
-     */
-    static const std::string RW_PANEL_CTRLSTATE;
-
-    /**
-     * \brief Panel operation mode.
-     */
-    static const std::string RW_PANEL_OPMODE;
-
-    /**
-     * \brief RAPID execution.
-     */
-    static const std::string RW_RAPID_EXECUTION;
-
-    /**
-     * \brief RAPID modules.
-     */
-    static const std::string RW_RAPID_MODULES;
-
-    /**
-     * \brief RAPID symbol data.
-     */
-    static const std::string RW_RAPID_SYMBOL_DATA_RAPID;
-
-    /**
-     * \brief RAPID symbol properties.
-     */
-    static const std::string RW_RAPID_SYMBOL_PROPERTIES_RAPID;
-
-    /**
-     * \brief RAPID tasks.
-     */
-    static const std::string RW_RAPID_TASKS;
-
-    /**
-     * \brief RobotWare system.
-     */
-    static const std::string RW_SYSTEM;
-  };
+  static const XMLAttribute CLASS_CTRL_TYPE;
 
   /**
-   * \brief RWS services.
+   * \brief Class & controller execution state.
    */
-  struct ABB_LIBRWS_EXPORT Services
-  {
-    /**
-     * \brief Controller service.
-     */
-    static const std::string CTRL;
+  static const XMLAttribute CLASS_CTRLEXECSTATE;
 
-    /**
-     * \brief Fileservice.
-     */
-    static const std::string FILESERVICE;
+  /**
+   * \brief Class & controller state.
+   */
+  static const XMLAttribute CLASS_CTRLSTATE;
 
-    /**
-     * \brief RobotWare service.
-     */
-    static const std::string RW;
+  /**
+   * \brief Class & data type.
+   */
+  static const XMLAttribute CLASS_DATTYP;
 
-    /**
-     * \brief Subscription service.
-     */
-    static const std::string SUBSCRIPTION;
+  /**
+   * \brief Class & excstate type.
+   */
+  static const XMLAttribute CLASS_EXCSTATE;
 
-    /**
-     * \brief User service.
-     */
-    static const std::string USERS;
-  };
+  /**
+   * \brief Class & ios-signal.
+   */
+  static const XMLAttribute CLASS_IOS_SIGNAL;
 
+  /**
+   * \brief Class & lvalue.
+   */
+  static const XMLAttribute CLASS_LVALUE;
 
-  /// @brief RWS 2.0 mastership domains.
-  ///
-  enum class MastershipDomain
-  {
-    edit,
-    motion
-  };
+  /**
+   * \brief Class & motiontask.
+   */
+  static const XMLAttribute CLASS_MOTIONTASK;
 
+  /**
+   * \brief Class & name.
+   */
+  static const XMLAttribute CLASS_NAME;
 
-  std::ostream& operator<<(std::ostream& os, MastershipDomain domain);
+  /**
+   * \brief Class & operation mode.
+   */
+  static const XMLAttribute CLASS_OPMODE;
 
+  /**
+   * \brief Class & rap-module-info-li.
+   */
+  static const XMLAttribute CLASS_RAP_MODULE_INFO_LI;
 
-  /// @brief Defines whether the mastership should be implicitly acquired when performing a request.
-  ///
-  enum class Mastership
-  {
-    Implicit,
-    Explicit
-  };
+  /**
+   * \brief Class & rap-task-li.
+   */
+  static const XMLAttribute CLASS_RAP_TASK_LI;
 
+  /**
+   * \brief Class & RobotWare version name.
+   */
+  static const XMLAttribute CLASS_RW_VERSION_NAME;
 
-  std::ostream& operator<<(std::ostream& os, Mastership mastership);
-}
+  /**
+   * \brief Class & state.
+   */
+  static const XMLAttribute CLASS_STATE;
+
+  /**
+   * \brief Class & sys-option-li.
+   */
+  static const XMLAttribute CLASS_SYS_OPTION_LI;
+
+  /**
+   * \brief Class & sys-system-li.
+   */
+  static const XMLAttribute CLASS_SYS_SYSTEM_LI;
+
+  /**
+   * \brief Class & type.
+   */
+  static const XMLAttribute CLASS_TYPE;
+
+  /**
+   * \brief Class & value.
+   */
+  static const XMLAttribute CLASS_VALUE;
+
+  /**
+   * \brief Class & option.
+   */
+  static const XMLAttribute CLASS_OPTION;
+};
+
+/**
+ * \brief Identifiers in different RWS messages. E.g. XML attribute names/values.
+ */
+struct ABB_LIBRWS_EXPORT Identifiers
+{
+  /**
+   * \brief Active type.
+   */
+  static const std::string ACTIVE;
+
+  /**
+   * \brief Configuration motion domain type: arm.
+   */
+  static const std::string ARM;
+
+  /**
+   * \brief XML attribute name: class.
+   */
+  static const std::string CLASS;
+
+  /**
+   * \brief Configuration instance list item.
+   */
+  static const std::string CFG_DT_INSTANCE_LI;
+
+  /**
+   * \brief Configuration list item.
+   */
+  static const std::string CFG_IA_T_LI;
+
+  /**
+   * \brief Controller type.
+   */
+  static const std::string CTRL_TYPE;
+
+  /**
+   * \brief Controller execution state.
+   */
+  static const std::string CTRLEXECSTATE;
+
+  /**
+   * \brief Controller state.
+   */
+  static const std::string CTRLSTATE;
+
+  /**
+   * \brief Data type.
+   */
+  static const std::string DATTYP;
+
+  /**
+   * \brief Execution state type.
+   */
+  static const std::string EXCSTATE;
+
+  /**
+   * \brief Home directory.
+   */
+  static const std::string HOME_DIRECTORY;
+
+  /**
+   * \brief IO signal.
+   */
+  static const std::string IOS_SIGNAL;
+
+  /**
+   * \brief Mechanical unit.
+   */
+  static const std::string MECHANICAL_UNIT;
+
+  /**
+   * \brief Mechanical unit group.
+   */
+  static const std::string MECHANICAL_UNIT_GROUP;
+
+  /**
+   * \brief Motion topic in the system configurations (abbreviated as moc).
+   */
+  static const std::string MOC;
+
+  /**
+   * \brief Module name.
+   */
+  static const std::string MODULE;
+
+  /**
+   * \brief Module path.
+   */
+  static const std::string MODULEPATH;
+
+  /**
+   * \brief Motion task.
+   */
+  static const std::string MOTIONTASK;
+
+  /**
+   * \brief Name.
+   */
+  static const std::string NAME;
+
+  /**
+   * \brief Lvalue.
+   */
+  static const std::string LVALUE;
+
+  /**
+   * \brief Opmode.
+   */
+  static const std::string OPMODE;
+
+  /**
+   * \brief Options present on the controller.
+   */
+  static const std::string PRESENT_OPTIONS;
+
+  /**
+   * \brief RAPID module info list item.
+   */
+  static const std::string RAP_MODULE_INFO_LI;
+
+  /**
+   * \brief RAPID task list item.
+   */
+  static const std::string RAP_TASK_LI;
+
+  /**
+   * \brief Robot.
+   */
+  static const std::string ROBOT;
+
+  /**
+   * \brief RobotWare version name.
+   */
+  static const std::string RW_VERSION_NAME;
+
+  /**
+   * \brief Single.
+   */
+  static const std::string SINGLE;
+
+  /**
+   * \brief State.
+   */
+  static const std::string STATE;
+
+  /**
+   * \brief Controller topic in the system configurations (abbreviated as sys).
+   */
+  static const std::string SYS;
+
+  /**
+   * \brief Sys option list item.
+   */
+  static const std::string SYS_OPTION_LI;
+
+  /**
+   * \brief Sys system list item.
+   */
+  static const std::string SYS_SYSTEM_LI;
+
+  /**
+   * \brief Title.
+   */
+  static const std::string TITLE;
+
+  /**
+   * \brief Type.
+   */
+  static const std::string TYPE;
+
+  /**
+   * \brief Value.
+   */
+  static const std::string VALUE;
+
+  /**
+   * \brief Option.
+   */
+  static const std::string OPTION;
+};
+
+/**
+ * \brief RWS queries.
+ */
+struct ABB_LIBRWS_EXPORT Queries
+{
+  /**
+   * \brief Load module action query.
+   */
+  static const std::string ACTION_LOAD_MODULE;
+
+  /**
+   * \brief Release action query.
+   */
+  static const std::string ACTION_RELEASE;
+
+  /**
+   * \brief Request action query.
+   */
+  static const std::string ACTION_REQUEST;
+
+  /**
+   * \brief Reset program pointer action query.
+   */
+  static const std::string ACTION_RESETPP;
+
+  /**
+   * \brief Set action query.
+   */
+  static const std::string ACTION_SET;
+
+  /**
+   * \brief Set controller state action query.
+   */
+  static const std::string ACTION_SETCTRLSTATE;
+
+  /**
+   * \brief Set locale.
+   */
+  static const std::string ACTION_SET_LOCALE;
+
+  /**
+   * \brief Start action query.
+   */
+  static const std::string ACTION_START;
+
+  /**
+   * \brief Stop action query.
+   */
+  static const std::string ACTION_STOP;
+
+  /**
+   * \brief Unload module action query.
+   */
+  static const std::string ACTION_UNLOAD_MODULE;
+
+  /**
+   * \brief Task query.
+   */
+  static const std::string TASK;
+};
+
+/**
+ * \brief RWS resources and queries.
+ */
+struct ABB_LIBRWS_EXPORT Resources
+{
+  /**
+   * \brief Instances.
+   */
+  static const std::string INSTANCES;
+
+  /**
+   * \brief Jointtarget.
+   */
+  static const std::string JOINTTARGET;
+
+  /**
+   * \brief Logout.
+   */
+  static const std::string LOGOUT;
+
+  /**
+   * \brief Robtarget.
+   */
+  static const std::string ROBTARGET;
+
+  /**
+   * \brief Configurations.
+   */
+  static const std::string RW_CFG;
+
+  /**
+   * \brief Signals.
+   */
+  static const std::string RW_IOSYSTEM_SIGNALS;
+
+  /**
+   * \brief Mastership.
+   */
+  static const std::string RW_MASTERSHIP;
+
+  /**
+   * \brief Mechanical units.
+   */
+  static const std::string RW_MOTIONSYSTEM_MECHUNITS;
+
+  /**
+   * \brief Panel controller state.
+   */
+  static const std::string RW_PANEL_CTRLSTATE;
+
+  /**
+   * \brief Panel operation mode.
+   */
+  static const std::string RW_PANEL_OPMODE;
+
+  /**
+   * \brief RAPID execution.
+   */
+  static const std::string RW_RAPID_EXECUTION;
+
+  /**
+   * \brief RAPID modules.
+   */
+  static const std::string RW_RAPID_MODULES;
+
+  /**
+   * \brief RAPID symbol data.
+   */
+  static const std::string RW_RAPID_SYMBOL_DATA_RAPID;
+
+  /**
+   * \brief RAPID symbol properties.
+   */
+  static const std::string RW_RAPID_SYMBOL_PROPERTIES_RAPID;
+
+  /**
+   * \brief RAPID tasks.
+   */
+  static const std::string RW_RAPID_TASKS;
+
+  /**
+   * \brief RobotWare system.
+   */
+  static const std::string RW_SYSTEM;
+};
+
+/**
+ * \brief RWS services.
+ */
+struct ABB_LIBRWS_EXPORT Services
+{
+  /**
+   * \brief Controller service.
+   */
+  static const std::string CTRL;
+
+  /**
+   * \brief Fileservice.
+   */
+  static const std::string FILESERVICE;
+
+  /**
+   * \brief RobotWare service.
+   */
+  static const std::string RW;
+
+  /**
+   * \brief Subscription service.
+   */
+  static const std::string SUBSCRIPTION;
+
+  /**
+   * \brief User service.
+   */
+  static const std::string USERS;
+};
+
+/// @brief RWS 2.0 mastership domains.
+///
+enum class MastershipDomain
+{
+  edit,
+  motion
+};
+
+std::ostream& operator<<(std::ostream& os, MastershipDomain domain);
+
+/// @brief Defines whether the mastership should be implicitly acquired when performing a request.
+///
+enum class Mastership
+{
+  Implicit,
+  Explicit
+};
+
+std::ostream& operator<<(std::ostream& os, Mastership mastership);
+}  // namespace abb::rws::v2_0

--- a/include/abb_librws/v2_0/rws_client.h
+++ b/include/abb_librws/v2_0/rws_client.h
@@ -49,14 +49,12 @@
 
 #include <map>
 
-
-namespace abb :: rws :: v2_0
+namespace abb ::rws ::v2_0
 {
 /**
  * \brief A struct for containing an evaluated communication result.
  */
 using RWSResult = Poco::AutoPtr<Poco::XML::Document>;
-
 
 /**
  * \brief A class for a Robot Web Services (RWS) 2.0 client.
@@ -65,8 +63,7 @@ using RWSResult = Poco::AutoPtr<Poco::XML::Document>;
  *
  * See https://developercenter.robotstudio.com/api/RWS for details about RWS 2.0
  */
-class RWSClient
-: public SubscriptionManager
+class RWSClient : public SubscriptionManager
 {
 public:
   /**
@@ -174,10 +171,8 @@ public:
    *
    * \throw \a RWSError if something goes wrong.
    */
-  RWSResult getMechanicalUnitRobTarget(const std::string& mechunit,
-                                       Coordinate coordinate = Coordinate::ACTIVE,
-                                       const std::string& tool = "",
-                                       const std::string& wobj = "");
+  RWSResult getMechanicalUnitRobTarget(const std::string& mechunit, Coordinate coordinate = Coordinate::ACTIVE,
+                                       const std::string& tool = "", const std::string& wobj = "");
 
   /**
    * \brief A method for retrieving info about the current robot controller system.
@@ -230,7 +225,6 @@ public:
    */
   void deleteFile(const FileResource& resource);
 
-
   /**
    * \brief A method for registering a user as local.
    *
@@ -241,8 +235,8 @@ public:
    * \throw \a RWSError if something goes wrong.
    */
   void registerLocalUser(const std::string& username = SystemConstants::General::DEFAULT_USERNAME,
-                              const std::string& application = SystemConstants::General::EXTERNAL_APPLICATION,
-                              const std::string& location = SystemConstants::General::EXTERNAL_LOCATION);
+                         const std::string& application = SystemConstants::General::EXTERNAL_APPLICATION,
+                         const std::string& location = SystemConstants::General::EXTERNAL_LOCATION);
 
   /**
    * \brief A method for registering a user as remote.
@@ -254,8 +248,8 @@ public:
    * \throw \a RWSError if something goes wrong.
    */
   void registerRemoteUser(const std::string& username = SystemConstants::General::DEFAULT_USERNAME,
-                               const std::string& application = SystemConstants::General::EXTERNAL_APPLICATION,
-                               const std::string& location = SystemConstants::General::EXTERNAL_LOCATION);
+                          const std::string& application = SystemConstants::General::EXTERNAL_APPLICATION,
+                          const std::string& location = SystemConstants::General::EXTERNAL_LOCATION);
 
   // SubscriptionManager implementation
   std::string openSubscription(std::vector<std::pair<std::string, SubscriptionPriority>> const& resources) override;
@@ -305,7 +299,6 @@ public:
    * \return POCOResult containing the result.
    */
   POCOResult httpDelete(const std::string& uri);
-
 
 private:
   /**
@@ -368,4 +361,4 @@ private:
   Poco::XML::DOMParser parser_;
   std::map<std::string, int> mastership_count_;
 };
-}
+}  // namespace abb::rws::v2_0

--- a/include/abb_librws/xml_attribute.h
+++ b/include/abb_librws/xml_attribute.h
@@ -2,18 +2,19 @@
 
 #include <string>
 
-
-namespace abb :: rws
+namespace abb ::rws
 {
-  /**
-   * \brief A struct for representing XML attributes.
-   */
-  struct XMLAttribute
-  {
+/**
+ * \brief A struct for representing XML attributes.
+ */
+struct XMLAttribute
+{
   /**
    * \brief A default constructor.
    */
-  XMLAttribute() {}
+  XMLAttribute()
+  {
+  }
 
   /**
    * \brief A constructor.
@@ -21,7 +22,9 @@ namespace abb :: rws
    * \param name for the attribute's name.
    * \param value for the attribute's value.
    */
-  XMLAttribute(const std::string& name, const std::string& value) : name(name), value(value) {}
+  XMLAttribute(const std::string& name, const std::string& value) : name(name), value(value)
+  {
+  }
 
   /**
    * \brief The name of the attribute.
@@ -32,5 +35,5 @@ namespace abb :: rws
    * \brief The value of the attribute.
    */
   std::string value;
-  };
-}
+};
+}  // namespace abb::rws

--- a/src/common/rw/panel.cpp
+++ b/src/common/rw/panel.cpp
@@ -5,122 +5,120 @@
 #include <stdexcept>
 #include <iostream>
 
-
-namespace abb :: rws :: rw
+namespace abb ::rws ::rw
 {
-    ControllerState makeControllerState(std::string const& str)
-    {
-        if (str == "init")
-            return ControllerState::init;
-        else if (str == "motoron")
-            return ControllerState::motorOn;
-        else if (str == "motoroff")
-            return ControllerState::motorOff;
-        else if (str == "guardstop")
-            return ControllerState::guardStop;
-        else if (str == "emergencystop")
-            return ControllerState::emergencyStop;
-        else if (str == "emergencystopreset")
-            return ControllerState::emergencyStopReset;
-        else if (str == "sysfail")
-            return ControllerState::sysFail;
-        else
-            BOOST_THROW_EXCEPTION(std::invalid_argument {"Unexpected string representation of controller state: \"" + str + "\""});
-    }
-
-
-    std::ostream& operator<<(std::ostream& os, ControllerState state)
-    {
-        switch (state)
-        {
-        case ControllerState::init:
-            os << "init";
-            break;
-        case ControllerState::motorOn:
-            os << "motoron";
-            break;
-        case ControllerState::motorOff:
-            os << "motoroff";
-            break;
-        case ControllerState::guardStop:
-            os << "guardstop";
-            break;
-        case ControllerState::emergencyStop:
-            os << "emergencystop";
-            break;
-        case ControllerState::emergencyStopReset:
-            os << "emergencystopreset";
-            break;
-        case ControllerState::sysFail:
-            os << "sysfail";
-            break;
-        default:
-            BOOST_THROW_EXCEPTION(std::logic_error {"Invalid ControllerState value"});
-        }
-
-        return os;
-    }
-
-
-    std::ostream& operator<<(std::ostream& os, OperationMode mode)
-    {
-        switch (mode)
-        {
-        case OperationMode::init:
-            os << "INIT";
-            break;
-        case OperationMode::autoCh:
-            os << "AUTO_CH";
-            break;
-        case OperationMode::manFCh:
-            os << "MANF_CH";
-            break;
-        case OperationMode::manR:
-            os << "MANR";
-            break;
-        case OperationMode::manF:
-            os << "MANF";
-            break;
-        case OperationMode::automatic:
-            os << "AUTO";
-            break;
-        case OperationMode::undef:
-            os << "UNDEF";
-            break;
-        default:
-            BOOST_THROW_EXCEPTION(std::logic_error {"Invalid OperationMode value"});
-        }
-
-        return os;
-    }
-
-
-    /**
-     * \brief Create \a OperationMode from string.
-     *
-     * \param str source string
-     *
-     * \return \a OperationMode matching the value of \a str
-     *
-     * \throw \a std::invalid_argument if \a str is not from the set of valid strings.
-     */
-    OperationMode makeOperationMode(std::string const& str)
-    {
-        if (str == "INIT")
-            return OperationMode::init;
-        else if (str == "AUTO_CH")
-            return OperationMode::autoCh;
-        else if (str == "MANF_CH")
-            return OperationMode::manFCh;
-        else if (str == "MANR")
-            return OperationMode::manR;
-        else if (str == "MANF")
-            return OperationMode::manF;
-        else if (str == "AUTO")
-            return OperationMode::automatic;
-        else if (str == "UNDEF")
-            return OperationMode::undef;
-        else
-            BOOST_THROW_EXCEPTION(std::invalid_argument {"Unexpected string representation of operation mode: \"" + str + "\""});
-    }
+ControllerState makeControllerState(std::string const& str)
+{
+  if (str == "init")
+    return ControllerState::init;
+  else if (str == "motoron")
+    return ControllerState::motorOn;
+  else if (str == "motoroff")
+    return ControllerState::motorOff;
+  else if (str == "guardstop")
+    return ControllerState::guardStop;
+  else if (str == "emergencystop")
+    return ControllerState::emergencyStop;
+  else if (str == "emergencystopreset")
+    return ControllerState::emergencyStopReset;
+  else if (str == "sysfail")
+    return ControllerState::sysFail;
+  else
+    BOOST_THROW_EXCEPTION(
+        std::invalid_argument{ "Unexpected string representation of controller state: \"" + str + "\"" });
 }
+
+std::ostream& operator<<(std::ostream& os, ControllerState state)
+{
+  switch (state)
+  {
+    case ControllerState::init:
+      os << "init";
+      break;
+    case ControllerState::motorOn:
+      os << "motoron";
+      break;
+    case ControllerState::motorOff:
+      os << "motoroff";
+      break;
+    case ControllerState::guardStop:
+      os << "guardstop";
+      break;
+    case ControllerState::emergencyStop:
+      os << "emergencystop";
+      break;
+    case ControllerState::emergencyStopReset:
+      os << "emergencystopreset";
+      break;
+    case ControllerState::sysFail:
+      os << "sysfail";
+      break;
+    default:
+      BOOST_THROW_EXCEPTION(std::logic_error{ "Invalid ControllerState value" });
+  }
+
+  return os;
+}
+
+std::ostream& operator<<(std::ostream& os, OperationMode mode)
+{
+  switch (mode)
+  {
+    case OperationMode::init:
+      os << "INIT";
+      break;
+    case OperationMode::autoCh:
+      os << "AUTO_CH";
+      break;
+    case OperationMode::manFCh:
+      os << "MANF_CH";
+      break;
+    case OperationMode::manR:
+      os << "MANR";
+      break;
+    case OperationMode::manF:
+      os << "MANF";
+      break;
+    case OperationMode::automatic:
+      os << "AUTO";
+      break;
+    case OperationMode::undef:
+      os << "UNDEF";
+      break;
+    default:
+      BOOST_THROW_EXCEPTION(std::logic_error{ "Invalid OperationMode value" });
+  }
+
+  return os;
+}
+
+/**
+ * \brief Create \a OperationMode from string.
+ *
+ * \param str source string
+ *
+ * \return \a OperationMode matching the value of \a str
+ *
+ * \throw \a std::invalid_argument if \a str is not from the set of valid strings.
+ */
+OperationMode makeOperationMode(std::string const& str)
+{
+  if (str == "INIT")
+    return OperationMode::init;
+  else if (str == "AUTO_CH")
+    return OperationMode::autoCh;
+  else if (str == "MANF_CH")
+    return OperationMode::manFCh;
+  else if (str == "MANR")
+    return OperationMode::manR;
+  else if (str == "MANF")
+    return OperationMode::manF;
+  else if (str == "AUTO")
+    return OperationMode::automatic;
+  else if (str == "UNDEF")
+    return OperationMode::undef;
+  else
+    BOOST_THROW_EXCEPTION(
+        std::invalid_argument{ "Unexpected string representation of operation mode: \"" + str + "\"" });
+}
+}  // namespace abb::rws::rw

--- a/src/common/rw/rapid.cpp
+++ b/src/common/rw/rapid.cpp
@@ -5,48 +5,47 @@
 #include <stdexcept>
 #include <iostream>
 
-
-namespace abb :: rws :: rw
+namespace abb ::rws ::rw
 {
-    RAPIDRunMode makeRAPIDRunMode(std::string const& str)
-    {
-        if (str == "forever")
-            return RAPIDRunMode::forever;
-        else if (str == "asis")
-            return RAPIDRunMode::asis;
-        else if (str == "once")
-            return RAPIDRunMode::once;
-        else if (str == "oncedone")
-            return RAPIDRunMode::oncedone;
-        else
-            BOOST_THROW_EXCEPTION(std::invalid_argument {"Unexpected string representation of RAPID run mode: \"" + str + "\""});
-    }
-
-
-    RAPIDExecutionState makeRAPIDExecutionState(std::string const& str)
-    {
-        if (str == "running")
-            return RAPIDExecutionState::running;
-        else if (str == "stopped")
-            return RAPIDExecutionState::stopped;
-        else
-            BOOST_THROW_EXCEPTION(std::invalid_argument {"Unexpected string representation of RAPID execution state: \"" + str + "\""});
-    }
-
-
-    std::ostream& operator<<(std::ostream& os, RAPIDExecutionState const& state)
-    {
-        switch (state)
-        {
-        case RAPIDExecutionState::stopped:
-            os << "stopped";
-            break;
-
-        case RAPIDExecutionState::running:
-            os << "running";
-            break;
-        }
-
-        return os;
-    }
+RAPIDRunMode makeRAPIDRunMode(std::string const& str)
+{
+  if (str == "forever")
+    return RAPIDRunMode::forever;
+  else if (str == "asis")
+    return RAPIDRunMode::asis;
+  else if (str == "once")
+    return RAPIDRunMode::once;
+  else if (str == "oncedone")
+    return RAPIDRunMode::oncedone;
+  else
+    BOOST_THROW_EXCEPTION(
+        std::invalid_argument{ "Unexpected string representation of RAPID run mode: \"" + str + "\"" });
 }
+
+RAPIDExecutionState makeRAPIDExecutionState(std::string const& str)
+{
+  if (str == "running")
+    return RAPIDExecutionState::running;
+  else if (str == "stopped")
+    return RAPIDExecutionState::stopped;
+  else
+    BOOST_THROW_EXCEPTION(
+        std::invalid_argument{ "Unexpected string representation of RAPID execution state: \"" + str + "\"" });
+}
+
+std::ostream& operator<<(std::ostream& os, RAPIDExecutionState const& state)
+{
+  switch (state)
+  {
+    case RAPIDExecutionState::stopped:
+      os << "stopped";
+      break;
+
+    case RAPIDExecutionState::running:
+      os << "running";
+      break;
+  }
+
+  return os;
+}
+}  // namespace abb::rws::rw

--- a/src/connection_options.cpp
+++ b/src/connection_options.cpp
@@ -1,24 +1,17 @@
 #include <abb_librws/connection_options.h>
 
-
-namespace abb :: rws
+namespace abb ::rws
 {
-    ConnectionOptions::ConnectionOptions(
-        std::string const& ip_address,
-        unsigned short port,
-        std::string const& username,
-        std::string password,
-        std::chrono::microseconds connection_timeout,
-        std::chrono::microseconds send_timeout,
-        std::chrono::microseconds receive_timeout
-    )
-    :   ip_address {ip_address}
-    ,   port {port}
-    ,   username {username}
-    ,   password {password}
-    ,   connection_timeout {connection_timeout}
-    ,   send_timeout {send_timeout}
-    ,   receive_timeout {receive_timeout}
-    {
-    }
+ConnectionOptions::ConnectionOptions(std::string const& ip_address, unsigned short port, std::string const& username,
+                                     std::string password, std::chrono::microseconds connection_timeout,
+                                     std::chrono::microseconds send_timeout, std::chrono::microseconds receive_timeout)
+  : ip_address{ ip_address }
+  , port{ port }
+  , username{ username }
+  , password{ password }
+  , connection_timeout{ connection_timeout }
+  , send_timeout{ send_timeout }
+  , receive_timeout{ receive_timeout }
+{
 }
+}  // namespace abb::rws

--- a/src/parsing.cpp
+++ b/src/parsing.cpp
@@ -8,278 +8,270 @@
 #include <Poco/DOM/NodeList.h>
 #include <Poco/DOM/DOMParser.h>
 
-
-namespace abb :: rws
+namespace abb ::rws
 {
-  Poco::AutoPtr<Poco::XML::Document> parseXml(std::string const& xml_string)
+Poco::AutoPtr<Poco::XML::Document> parseXml(std::string const& xml_string)
+{
+  static thread_local Poco::XML::DOMParser parser;
+  return parser.parseString(xml_string);
+}
+
+std::vector<Poco::XML::Node*> xmlFindNodes(Poco::XML::Node* p_root, const XMLAttribute& attribute)
+{
+  std::vector<Poco::XML::Node*> result;
+
+  if (p_root)
   {
-    static thread_local Poco::XML::DOMParser parser;
-    return parser.parseString(xml_string);
+    bool found = false;
+
+    Poco::XML::NodeIterator node_iterator(p_root, Poco::XML::NodeFilter::SHOW_ELEMENT);
+    Poco::XML::Node* p_node = node_iterator.nextNode();
+
+    while (p_node)
+    {
+      if (xmlNodeHasAttribute(p_node, attribute))
+      {
+        result.push_back(p_node);
+      }
+
+      p_node = node_iterator.nextNode();
+    }
   }
 
+  return result;
+}
 
-  std::vector<Poco::XML::Node*> xmlFindNodes(Poco::XML::Node* p_root, const XMLAttribute& attribute)
+std::vector<Poco::XML::Node*> xmlFindNodes(Poco::AutoPtr<Poco::XML::Document> p_xml_document,
+                                           const XMLAttribute& attribute)
+{
+  std::vector<Poco::XML::Node*> result;
+
+  if (!p_xml_document.isNull())
   {
-    std::vector<Poco::XML::Node*> result;
+    Poco::XML::NodeIterator node_iterator(p_xml_document, Poco::XML::NodeFilter::SHOW_ELEMENT);
+    Poco::XML::Node* p_node = node_iterator.nextNode();
 
-    if(p_root)
+    while (p_node)
+    {
+      if (xmlNodeHasAttribute(p_node, attribute))
+      {
+        result.push_back(p_node);
+      }
+
+      p_node = node_iterator.nextNode();
+    }
+  }
+
+  return result;
+}
+
+std::string xmlFindTextContent(Poco::AutoPtr<Poco::XML::Document> p_xml_document, const XMLAttribute& attribute)
+{
+  std::string result;
+
+  if (!p_xml_document.isNull())
+  {
+    Poco::XML::NodeIterator node_iterator(p_xml_document, Poco::XML::NodeFilter::SHOW_ELEMENT);
+    result = xmlFindTextContent(node_iterator.nextNode(), attribute);
+  }
+
+  return result;
+}
+
+std::string xmlFindTextContent(const Poco::XML::Node* p_node, const XMLAttribute& attribute)
+{
+  std::string result;
+
+  if (p_node)
+  {
+    if (p_node->nodeType() == Poco::XML::Node::TEXT_NODE && xmlNodeHasAttribute(p_node->parentNode(), attribute))
+    {
+      result = p_node->nodeValue();
+    }
+    else
     {
       bool found = false;
-
-      Poco::XML::NodeIterator node_iterator(p_root, Poco::XML::NodeFilter::SHOW_ELEMENT);
-      Poco::XML::Node* p_node = node_iterator.nextNode();
-
-      while (p_node)
+      if (p_node->hasChildNodes())
       {
-        if (xmlNodeHasAttribute(p_node, attribute))
+        Poco::AutoPtr<Poco::XML::NodeList> p_children(p_node->childNodes());
+
+        for (unsigned long i = 0; i < p_children->length() && !found; i++)
         {
-          result.push_back(p_node);
-        }
+          Poco::XML::Node* p_child = p_children->item(i);
 
-        p_node = node_iterator.nextNode();
-      }
-    }
-
-    return result;
-  }
-
-  std::vector<Poco::XML::Node*> xmlFindNodes(Poco::AutoPtr<Poco::XML::Document> p_xml_document,
-                                            const XMLAttribute& attribute)
-  {
-    std::vector<Poco::XML::Node*> result;
-
-    if (!p_xml_document.isNull())
-    {
-      Poco::XML::NodeIterator node_iterator(p_xml_document, Poco::XML::NodeFilter::SHOW_ELEMENT);
-      Poco::XML::Node* p_node = node_iterator.nextNode();
-
-      while (p_node)
-      {
-        if (xmlNodeHasAttribute(p_node, attribute))
-        {
-          result.push_back(p_node);
-        }
-
-        p_node = node_iterator.nextNode();
-      }
-    }
-
-    return result;
-  }
-
-  std::string xmlFindTextContent(Poco::AutoPtr<Poco::XML::Document> p_xml_document, const XMLAttribute& attribute)
-  {
-    std::string result;
-
-    if (!p_xml_document.isNull())
-    {
-      Poco::XML::NodeIterator node_iterator(p_xml_document, Poco::XML::NodeFilter::SHOW_ELEMENT);
-      result = xmlFindTextContent(node_iterator.nextNode(), attribute);
-    }
-
-    return result;
-  }
-
-  std::string xmlFindTextContent(const Poco::XML::Node* p_node, const XMLAttribute& attribute)
-  {
-    std::string result;
-
-    if (p_node)
-    {
-      if (p_node->nodeType() == Poco::XML::Node::TEXT_NODE && xmlNodeHasAttribute(p_node->parentNode(), attribute))
-      {
-        result = p_node->nodeValue();
-      }
-      else
-      {
-        bool found = false;
-        if (p_node->hasChildNodes())
-        {
-          Poco::AutoPtr<Poco::XML::NodeList> p_children(p_node->childNodes());
-
-          for (unsigned long i = 0; i < p_children->length() && !found; i++)
+          if (p_child->nodeType() == Poco::XML::Node::TEXT_NODE &&
+              xmlNodeHasAttribute(p_child->parentNode(), attribute))
           {
-            Poco::XML::Node* p_child = p_children->item(i);
-
-            if (p_child->nodeType() == Poco::XML::Node::TEXT_NODE &&
-                xmlNodeHasAttribute(p_child->parentNode(), attribute))
-            {
-              found = true;
-              result = p_child->nodeValue();
-            }
-            else
-            {
-              result = xmlFindTextContent(p_child, attribute);
-              found = !result.empty();
-            }
-          }
-        }
-      }
-    }
-
-    return result;
-  }
-
-  std::string xmlNodeGetAttributeValue(const Poco::XML::Node* p_node, const std::string& name)
-  {
-    std::string result;
-
-    if (p_node && p_node->hasAttributes() && !name.empty())
-    {
-      Poco::AutoPtr<Poco::XML::NamedNodeMap> p_attributes(p_node->attributes());
-
-      for (unsigned long i = 0; i < p_attributes->length(); ++i)
-      {
-        Poco::XML::Node* p_attribute = p_attributes->item(i);
-
-        if (p_attribute->nodeName() == name)
-        {
-          return p_attribute->nodeValue();
-        }
-      }
-    }
-
-    return result;
-  }
-
-  bool xmlNodeHasAttribute(const Poco::XML::Node* p_node, const XMLAttribute& attribute)
-  {
-    bool found = attribute.name.empty() && attribute.value.empty();
-
-    if(!found && p_node && p_node->hasAttributes())
-    {
-      Poco::AutoPtr<Poco::XML::NamedNodeMap> p_attributes(p_node->attributes());
-
-      for (unsigned long i = 0; i < p_attributes->length() && !found; i++)
-      {
-        Poco::XML::Node* p_attribute = p_attributes->item(i);
-
-        if (p_attribute->nodeName() == attribute.name && p_attribute->nodeValue() == attribute.value)
-        {
-          found = true;
-        }
-      }
-    }
-
-    return found;
-  }
-
-  bool xmlNodeHasAttribute(const Poco::XML::Node* p_node, const std::string& name, const std::string& value)
-  {
-    return xmlNodeHasAttribute(p_node, XMLAttribute(name, value));
-  }
-
-
-  std::string findSubstringContent(const std::string& whole_string,
-                                              const std::string& substring_start,
-                                              const std::string& substring_end)
-  {
-    std::string result;
-    size_t start_postion = whole_string.find(substring_start);
-
-    if (start_postion != std::string::npos)
-    {
-      start_postion += substring_start.size();
-      size_t end_postion = whole_string.find_first_of(substring_end, start_postion);
-
-      if (end_postion != std::string::npos)
-      {
-        result = whole_string.substr(start_postion, end_postion - start_postion);
-      }
-    }
-
-    std::string quot = "&quot;";
-    size_t quot_position = 0;
-    do
-    {
-      quot_position = result.find(quot);
-      if (quot_position != std::string::npos)
-      {
-        result.replace(quot_position, quot.size(), "");
-      }
-    } while (quot_position != std::string::npos);
-
-    return result;
-  }
-
-  unsigned int countCharInString(std::string input, const char character)
-  {
-    bool done = false;
-    unsigned int count = 0;
-    size_t position = 0;
-
-    do
-    {
-      position = input.find_first_of(character);
-
-      if (position != std::string::npos)
-      {
-        ++count;
-        input.erase(position, 1);
-      }
-      else
-      {
-        done = true;
-      }
-    } while (!done);
-
-    return count;
-  }
-
-  std::vector<std::string> extractDelimitedSubstrings(
-      const std::string& input,
-      const char start_delimiter,
-      const char end_delimiter,
-      const char separator
-    )
-  {
-    // Prepare the input by removing any starting and ending '[' respective ']'
-    std::string temp_0(input);
-    size_t position_1 = 0;
-    size_t position_2 = 0;
-
-    position_1 = temp_0.find_first_of(start_delimiter);
-    position_2 = temp_0.find_last_of(end_delimiter);
-
-    if (position_1 != std::string::npos && position_2 != std::string::npos)
-    {
-      temp_0.erase(position_1, 1);
-      temp_0.erase(position_2 - 1, 1);
-    }
-
-    // Extract and merge the delimited substrings in the prepared input string.
-    std::stringstream ss(temp_0);
-    std::vector<std::string> values;
-    std::string temp_1;
-    std::string temp_2;
-    int counter = 0;
-
-    while (std::getline(ss, temp_1, separator))
-    {
-      if (!temp_1.empty())
-      {
-        counter += countCharInString(temp_1, start_delimiter);
-        counter -= countCharInString(temp_1, end_delimiter);
-
-        if (counter == 0)
-        {
-          if (!temp_2.empty())
-          {
-            values.push_back(temp_2 + temp_1);
-            temp_2 = "";
+            found = true;
+            result = p_child->nodeValue();
           }
           else
           {
-            values.push_back(temp_1);
+            result = xmlFindTextContent(p_child, attribute);
+            found = !result.empty();
           }
-        }
-        else
-        {
-          temp_2 += temp_1 + ",";
         }
       }
     }
-
-    return values;
   }
+
+  return result;
 }
+
+std::string xmlNodeGetAttributeValue(const Poco::XML::Node* p_node, const std::string& name)
+{
+  std::string result;
+
+  if (p_node && p_node->hasAttributes() && !name.empty())
+  {
+    Poco::AutoPtr<Poco::XML::NamedNodeMap> p_attributes(p_node->attributes());
+
+    for (unsigned long i = 0; i < p_attributes->length(); ++i)
+    {
+      Poco::XML::Node* p_attribute = p_attributes->item(i);
+
+      if (p_attribute->nodeName() == name)
+      {
+        return p_attribute->nodeValue();
+      }
+    }
+  }
+
+  return result;
+}
+
+bool xmlNodeHasAttribute(const Poco::XML::Node* p_node, const XMLAttribute& attribute)
+{
+  bool found = attribute.name.empty() && attribute.value.empty();
+
+  if (!found && p_node && p_node->hasAttributes())
+  {
+    Poco::AutoPtr<Poco::XML::NamedNodeMap> p_attributes(p_node->attributes());
+
+    for (unsigned long i = 0; i < p_attributes->length() && !found; i++)
+    {
+      Poco::XML::Node* p_attribute = p_attributes->item(i);
+
+      if (p_attribute->nodeName() == attribute.name && p_attribute->nodeValue() == attribute.value)
+      {
+        found = true;
+      }
+    }
+  }
+
+  return found;
+}
+
+bool xmlNodeHasAttribute(const Poco::XML::Node* p_node, const std::string& name, const std::string& value)
+{
+  return xmlNodeHasAttribute(p_node, XMLAttribute(name, value));
+}
+
+std::string findSubstringContent(const std::string& whole_string, const std::string& substring_start,
+                                 const std::string& substring_end)
+{
+  std::string result;
+  size_t start_postion = whole_string.find(substring_start);
+
+  if (start_postion != std::string::npos)
+  {
+    start_postion += substring_start.size();
+    size_t end_postion = whole_string.find_first_of(substring_end, start_postion);
+
+    if (end_postion != std::string::npos)
+    {
+      result = whole_string.substr(start_postion, end_postion - start_postion);
+    }
+  }
+
+  std::string quot = "&quot;";
+  size_t quot_position = 0;
+  do
+  {
+    quot_position = result.find(quot);
+    if (quot_position != std::string::npos)
+    {
+      result.replace(quot_position, quot.size(), "");
+    }
+  } while (quot_position != std::string::npos);
+
+  return result;
+}
+
+unsigned int countCharInString(std::string input, const char character)
+{
+  bool done = false;
+  unsigned int count = 0;
+  size_t position = 0;
+
+  do
+  {
+    position = input.find_first_of(character);
+
+    if (position != std::string::npos)
+    {
+      ++count;
+      input.erase(position, 1);
+    }
+    else
+    {
+      done = true;
+    }
+  } while (!done);
+
+  return count;
+}
+
+std::vector<std::string> extractDelimitedSubstrings(const std::string& input, const char start_delimiter,
+                                                    const char end_delimiter, const char separator)
+{
+  // Prepare the input by removing any starting and ending '[' respective ']'
+  std::string temp_0(input);
+  size_t position_1 = 0;
+  size_t position_2 = 0;
+
+  position_1 = temp_0.find_first_of(start_delimiter);
+  position_2 = temp_0.find_last_of(end_delimiter);
+
+  if (position_1 != std::string::npos && position_2 != std::string::npos)
+  {
+    temp_0.erase(position_1, 1);
+    temp_0.erase(position_2 - 1, 1);
+  }
+
+  // Extract and merge the delimited substrings in the prepared input string.
+  std::stringstream ss(temp_0);
+  std::vector<std::string> values;
+  std::string temp_1;
+  std::string temp_2;
+  int counter = 0;
+
+  while (std::getline(ss, temp_1, separator))
+  {
+    if (!temp_1.empty())
+    {
+      counter += countCharInString(temp_1, start_delimiter);
+      counter -= countCharInString(temp_1, end_delimiter);
+
+      if (counter == 0)
+      {
+        if (!temp_2.empty())
+        {
+          values.push_back(temp_2 + temp_1);
+          temp_2 = "";
+        }
+        else
+        {
+          values.push_back(temp_1);
+        }
+      }
+      else
+      {
+        temp_2 += temp_1 + ",";
+      }
+    }
+  }
+
+  return values;
+}
+}  // namespace abb::rws

--- a/src/rws.cpp
+++ b/src/rws.cpp
@@ -5,47 +5,45 @@
 #include <stdexcept>
 #include <iostream>
 
-
-namespace abb :: rws
+namespace abb ::rws
 {
-  std::ostream& operator<<(std::ostream& os, StopMode stopmode)
+std::ostream& operator<<(std::ostream& os, StopMode stopmode)
+{
+  switch (stopmode)
   {
-    switch (stopmode)
-    {
-      case StopMode::cycle:
-        os << "cycle";
-        break;
-      case StopMode::instr:
-        os << "instr";
-        break;
-      case StopMode::stop:
-        os << "stop";
-        break;
-      case StopMode::qstop:
-        os << "qstop";
-        break;
-      default:
-        BOOST_THROW_EXCEPTION(std::logic_error {"Invalid StopMode value"});
-    }
-
-    return os;
+    case StopMode::cycle:
+      os << "cycle";
+      break;
+    case StopMode::instr:
+      os << "instr";
+      break;
+    case StopMode::stop:
+      os << "stop";
+      break;
+    case StopMode::qstop:
+      os << "qstop";
+      break;
+    default:
+      BOOST_THROW_EXCEPTION(std::logic_error{ "Invalid StopMode value" });
   }
 
-
-  std::ostream& operator<<(std::ostream& os, UseTsp usetsp)
-  {
-    switch (usetsp)
-    {
-      case UseTsp::normal:
-        os << "normal";
-        break;
-      case UseTsp::alltsk:
-        os << "alltsk";
-        break;
-      default:
-        BOOST_THROW_EXCEPTION(std::logic_error {"Invalid UseTsp value"});
-    }
-
-    return os;
-  }
+  return os;
 }
+
+std::ostream& operator<<(std::ostream& os, UseTsp usetsp)
+{
+  switch (usetsp)
+  {
+    case UseTsp::normal:
+      os << "normal";
+      break;
+    case UseTsp::alltsk:
+      os << "alltsk";
+      break;
+    default:
+      BOOST_THROW_EXCEPTION(std::logic_error{ "Invalid UseTsp value" });
+  }
+
+  return os;
+}
+}  // namespace abb::rws

--- a/src/rws_poco_client.cpp
+++ b/src/rws_poco_client.cpp
@@ -43,7 +43,6 @@
 #include <abb_librws/rws_poco_client.h>
 #include <abb_librws/rws_error.h>
 
-
 using namespace Poco;
 using namespace Poco::Net;
 
@@ -55,12 +54,8 @@ namespace rws
  * Class definitions: POCOClient
  */
 
-POCOClient::POCOClient(
-  Poco::Net::HTTPClientSession& session,
-  const std::string& username,
-  const std::string& password)
-: http_client_session_ {session}
-, http_credentials_ {username, password}
+POCOClient::POCOClient(Poco::Net::HTTPClientSession& session, const std::string& username, const std::string& password)
+  : http_client_session_{ session }, http_credentials_{ username, password }
 {
   http_client_session_.setKeepAlive(true);
 }
@@ -93,10 +88,8 @@ POCOResult POCOClient::httpDelete(const std::string& uri)
   return makeHTTPRequest(HTTPRequest::HTTP_DELETE, uri);
 }
 
-POCOResult POCOClient::makeHTTPRequest(const std::string& method,
-                                                   const std::string& uri,
-                                                   const std::string& content,
-                                                   const std::string& content_type)
+POCOResult POCOClient::makeHTTPRequest(const std::string& method, const std::string& uri, const std::string& content,
+                                       const std::string& content_type)
 {
   // The response and the request.
   HTTPResponse response;
@@ -110,7 +103,8 @@ POCOResult POCOClient::makeHTTPRequest(const std::string& method,
   if (!content_type.empty())
   {
     request.setContentType(content_type);
-  } else if (method == HTTPRequest::HTTP_POST || !content.empty())
+  }
+  else if (method == HTTPRequest::HTTP_POST || !content.empty())
   {
     request.setContentType("application/x-www-form-urlencoded");
   }
@@ -149,8 +143,7 @@ POCOResult POCOClient::makeHTTPRequest(const std::string& method,
       authenticate(request, response, content, response_content);
     }
 
-
-    return POCOResult {response.getStatus(), response.getReason(), response, response_content};
+    return POCOResult{ response.getStatus(), response.getReason(), response, response_content };
   }
   catch (CommunicationError const&)
   {
@@ -161,8 +154,8 @@ POCOResult POCOClient::makeHTTPRequest(const std::string& method,
   }
 }
 
-
-Poco::Net::WebSocket POCOClient::webSocketConnect(const std::string& uri, const std::string& protocol, Poco::Net::HTTPClientSession&& session)
+Poco::Net::WebSocket POCOClient::webSocketConnect(const std::string& uri, const std::string& protocol,
+                                                  Poco::Net::HTTPClientSession&& session)
 {
   // The response and the request.
   HTTPResponse response;
@@ -173,40 +166,30 @@ Poco::Net::WebSocket POCOClient::webSocketConnect(const std::string& uri, const 
   // Attempt the communication.
   try
   {
-    Poco::Net::WebSocket websocket {session, request, response};
+    Poco::Net::WebSocket websocket{ session, request, response };
 
     if (response.getStatus() != HTTPResponse::HTTP_SWITCHING_PROTOCOLS)
-      BOOST_THROW_EXCEPTION(
-        ProtocolError {"webSocketConnect() failed"}
-          << HttpStatusErrorInfo {response.getStatus()}
-          << HttpReasonErrorInfo {response.getReason()}
-          << HttpMethodErrorInfo {request.getMethod()}
-          << UriErrorInfo {uri}
-      );
+      BOOST_THROW_EXCEPTION(ProtocolError{ "webSocketConnect() failed" } << HttpStatusErrorInfo{ response.getStatus() }
+                                                                         << HttpReasonErrorInfo{ response.getReason() }
+                                                                         << HttpMethodErrorInfo{ request.getMethod() }
+                                                                         << UriErrorInfo{ uri });
 
     return websocket;
   }
   catch (Poco::Exception const& e)
   {
-    BOOST_THROW_EXCEPTION(
-      CommunicationError {"webSocketConnect() failed: " + e.displayText()}
-        << HttpStatusErrorInfo {response.getStatus()}
-        << HttpReasonErrorInfo {response.getReason()}
-        << HttpMethodErrorInfo {request.getMethod()}
-        << UriErrorInfo {uri}
-        << boost::errinfo_nested_exception {boost::current_exception()}
-    );
+    BOOST_THROW_EXCEPTION(CommunicationError{ "webSocketConnect() failed: " + e.displayText() }
+                          << HttpStatusErrorInfo{ response.getStatus() } << HttpReasonErrorInfo{ response.getReason() }
+                          << HttpMethodErrorInfo{ request.getMethod() } << UriErrorInfo{ uri }
+                          << boost::errinfo_nested_exception{ boost::current_exception() });
   }
 }
-
 
 /************************************************************
  * Auxiliary methods
  */
 
-void POCOClient::sendAndReceive(HTTPRequest& request,
-                                HTTPResponse& response,
-                                const std::string& request_content,
+void POCOClient::sendAndReceive(HTTPRequest& request, HTTPResponse& response, const std::string& request_content,
                                 std::string& response_content)
 {
   HTTPInfo log_entry;
@@ -223,13 +206,10 @@ void POCOClient::sendAndReceive(HTTPRequest& request,
   }
   catch (Poco::Exception const& e)
   {
-    BOOST_THROW_EXCEPTION(
-      CommunicationError {"HTTP send error: " + e.displayText()}
-        << HttpMethodErrorInfo {request.getMethod()}
-        << UriErrorInfo {request.getURI()}
-        << HttpRequestContentErrorInfo {request_content}
-        << boost::errinfo_nested_exception {boost::current_exception()}
-    );
+    BOOST_THROW_EXCEPTION(CommunicationError{ "HTTP send error: " + e.displayText() }
+                          << HttpMethodErrorInfo{ request.getMethod() } << UriErrorInfo{ request.getURI() }
+                          << HttpRequestContentErrorInfo{ request_content }
+                          << boost::errinfo_nested_exception{ boost::current_exception() });
   }
 
   try
@@ -241,13 +221,10 @@ void POCOClient::sendAndReceive(HTTPRequest& request,
   }
   catch (Poco::Exception const& e)
   {
-    BOOST_THROW_EXCEPTION(
-      CommunicationError {"HTTP receive error: " + e.displayText()}
-        << HttpMethodErrorInfo {request.getMethod()}
-        << UriErrorInfo {request.getURI()}
-        << HttpRequestContentErrorInfo {request_content}
-        << boost::errinfo_nested_exception {boost::current_exception()}
-    );
+    BOOST_THROW_EXCEPTION(CommunicationError{ "HTTP receive error: " + e.displayText() }
+                          << HttpMethodErrorInfo{ request.getMethod() } << UriErrorInfo{ request.getURI() }
+                          << HttpRequestContentErrorInfo{ request_content }
+                          << boost::errinfo_nested_exception{ boost::current_exception() });
   }
 
   // Add response info to the log entry.
@@ -262,10 +239,7 @@ void POCOClient::sendAndReceive(HTTPRequest& request,
   log_.push_front(log_entry);
 }
 
-
-void POCOClient::authenticate(HTTPRequest& request,
-                              HTTPResponse& response,
-                              const std::string& request_content,
+void POCOClient::authenticate(HTTPRequest& request, HTTPResponse& response, const std::string& request_content,
                               std::string& response_content)
 {
   // Remove any old cookies.
@@ -301,7 +275,6 @@ void POCOClient::extractAndStoreCookie(const std::string& cookie_string)
   }
 }
 
-
 std::string POCOClient::getLogText(bool verbose) const
 {
   if (log_.size() == 0)
@@ -321,22 +294,18 @@ std::string POCOClient::getLogText(bool verbose) const
   return ss.str();
 }
 
-
 std::string POCOClient::getLogTextLatestEvent(bool verbose) const
 {
   return (log_.size() == 0 ? "" : log_[0].toString(verbose, 0));
 }
 
-
-void POCOClient::HTTPInfo::addHTTPRequestInfo(const Poco::Net::HTTPRequest& request,
-                                                const std::string& request_content)
+void POCOClient::HTTPInfo::addHTTPRequestInfo(const Poco::Net::HTTPRequest& request, const std::string& request_content)
 {
-  this->request = {request.getMethod(), request.getURI(), request_content};
+  this->request = { request.getMethod(), request.getURI(), request_content };
 }
 
-
 void POCOClient::HTTPInfo::addHTTPResponseInfo(const Poco::Net::HTTPResponse& response,
-                                                const std::string& response_content)
+                                               const std::string& response_content)
 {
   std::string header_info;
 
@@ -345,9 +314,8 @@ void POCOClient::HTTPInfo::addHTTPResponseInfo(const Poco::Net::HTTPResponse& re
     header_info += i->first + "=" + i->second + "\n";
   }
 
-  this->response = HTTPInfo::ResponseInfo {response.getStatus(), header_info, response_content};
+  this->response = HTTPInfo::ResponseInfo{ response.getStatus(), header_info, response_content };
 }
-
 
 std::string POCOClient::HTTPInfo::toString(bool verbose, size_t indent) const
 {
@@ -363,7 +331,7 @@ std::string POCOClient::HTTPInfo::toString(bool verbose, size_t indent) const
   if (response)
   {
     ss << seperator << "HTTP Response: " << response->status << " - "
-      << HTTPResponse::getReasonForStatus(response->status);
+       << HTTPResponse::getReasonForStatus(response->status);
 
     if (verbose)
     {
@@ -374,5 +342,5 @@ std::string POCOClient::HTTPInfo::toString(bool verbose, size_t indent) const
   return ss.str();
 }
 
-} // end namespace rws
-} // end namespace abb
+}  // end namespace rws
+}  // end namespace abb

--- a/src/rws_poco_result.cpp
+++ b/src/rws_poco_result.cpp
@@ -4,22 +4,18 @@
 
 #include <sstream>
 
-
 using namespace Poco;
 using namespace Poco::Net;
 
-
-namespace abb :: rws
+namespace abb ::rws
 {
-  /***********************************************************************************************************************
-   * Struct definitions: POCOResult
-   */
-  POCOResult::POCOResult(Poco::Net::HTTPResponse::HTTPStatus http_status, std::string const& reason,
-    Poco::Net::NameValueCollection const& header_info, std::string const& content)
-  : httpStatus_ {http_status}
-  , reason_ {reason}
+/***********************************************************************************************************************
+ * Struct definitions: POCOResult
+ */
+POCOResult::POCOResult(Poco::Net::HTTPResponse::HTTPStatus http_status, std::string const& reason,
+                       Poco::Net::NameValueCollection const& header_info, std::string const& content)
+  : httpStatus_{ http_status }
+  , reason_{ reason }
   , headerInfo_(header_info.begin(), header_info.end())
-  , content_ {content}
-  {
-  };
-}
+  , content_{ content } {};
+}  // namespace abb::rws

--- a/src/rws_rapid.cpp
+++ b/src/rws_rapid.cpp
@@ -135,9 +135,6 @@ void RAPIDAtomic<RAPID_STRING>::parseString(const std::string& value_string)
   value = temp;
 }
 
-
-
-
 /***********************************************************************************************************************
  * Class definitions: RAPIDRecord
  */
@@ -146,10 +143,9 @@ void RAPIDAtomic<RAPID_STRING>::parseString(const std::string& value_string)
  * Primary methods
  */
 
-RAPIDRecord::RAPIDRecord(const std::string& record_type_name)
-:
-record_type_name_(record_type_name)
-{}
+RAPIDRecord::RAPIDRecord(const std::string& record_type_name) : record_type_name_(record_type_name)
+{
+}
 
 std::string RAPIDRecord::getType() const
 {
@@ -209,5 +205,5 @@ RAPIDRecord& RAPIDRecord::operator=(const RAPIDRecord& other)
   return *this;
 }
 
-} // end namespace rws
-} // end namespace abb
+}  // end namespace rws
+}  // end namespace abb

--- a/src/rws_state_machine_interface.cpp
+++ b/src/rws_state_machine_interface.cpp
@@ -44,37 +44,37 @@ namespace rws
  * Struct definitions: RWSStateMachineInterface::ResourceIdentifiers
  */
 
-typedef RWSStateMachineInterface::States                                 States;
-typedef RWSStateMachineInterface::EGMActions                             EGMActions;
-typedef RWSStateMachineInterface::ResourceIdentifiers::RAPID::Symbols    Symbols;
-typedef RWSStateMachineInterface::ResourceIdentifiers::IOSignals         IOSignals;
-typedef RWSStateMachineInterface::ResourceIdentifiers::RAPID::Modules    Modules;
+typedef RWSStateMachineInterface::States States;
+typedef RWSStateMachineInterface::EGMActions EGMActions;
+typedef RWSStateMachineInterface::ResourceIdentifiers::RAPID::Symbols Symbols;
+typedef RWSStateMachineInterface::ResourceIdentifiers::IOSignals IOSignals;
+typedef RWSStateMachineInterface::ResourceIdentifiers::RAPID::Modules Modules;
 typedef RWSStateMachineInterface::ResourceIdentifiers::RAPID::Procedures Procedures;
-typedef RWSStateMachineInterface::ResourceIdentifiers::RAPID::Symbols    Symbols;
+typedef RWSStateMachineInterface::ResourceIdentifiers::RAPID::Symbols Symbols;
 
-const std::string IOSignals::EGM_START_JOINT    = "EGM_START_JOINT";
-const std::string IOSignals::EGM_START_POSE     = "EGM_START_POSE";
-const std::string IOSignals::EGM_START_STREAM   = "EGM_START_STREAM";
-const std::string IOSignals::EGM_STOP           = "EGM_STOP";
-const std::string IOSignals::EGM_STOP_STREAM    = "EGM_STOP_STREAM";
-const std::string IOSignals::OUTPUT_STATIONARY  = "OUTPUT_STATIONARY";
-const std::string IOSignals::RUN_RAPID_ROUTINE  = "RUN_RAPID_ROUTINE";
-const std::string IOSignals::RUN_SG_ROUTINE     = "RUN_SG_ROUTINE";
+const std::string IOSignals::EGM_START_JOINT = "EGM_START_JOINT";
+const std::string IOSignals::EGM_START_POSE = "EGM_START_POSE";
+const std::string IOSignals::EGM_START_STREAM = "EGM_START_STREAM";
+const std::string IOSignals::EGM_STOP = "EGM_STOP";
+const std::string IOSignals::EGM_STOP_STREAM = "EGM_STOP_STREAM";
+const std::string IOSignals::OUTPUT_STATIONARY = "OUTPUT_STATIONARY";
+const std::string IOSignals::RUN_RAPID_ROUTINE = "RUN_RAPID_ROUTINE";
+const std::string IOSignals::RUN_SG_ROUTINE = "RUN_SG_ROUTINE";
 const std::string IOSignals::WD_EXTERNAL_STATUS = "WD_EXTERNAL_STATUS";
-const std::string IOSignals::WD_STOP_REQUEST    = "WD_STOP_REQUEST";
+const std::string IOSignals::WD_STOP_REQUEST = "WD_STOP_REQUEST";
 
-const std::string Modules::T_ROB_EGM      = "TRobEGM";
-const std::string Modules::T_ROB_MAIN     = "TRobMain";
-const std::string Modules::T_ROB_RAPID    = "TRobRAPID";
-const std::string Modules::T_ROB_SG       = "TRobSG";
-const std::string Modules::T_ROB_UTILITY  = "TRobUtility";
+const std::string Modules::T_ROB_EGM = "TRobEGM";
+const std::string Modules::T_ROB_MAIN = "TRobMain";
+const std::string Modules::T_ROB_RAPID = "TRobRAPID";
+const std::string Modules::T_ROB_SG = "TRobSG";
+const std::string Modules::T_ROB_UTILITY = "TRobUtility";
 const std::string Modules::T_ROB_WATCHDOG = "TRobWatchdog";
 
-const std::string Procedures::RUN_CALL_BY_VAR                  = "runCallByVar";
-const std::string Procedures::RUN_MODULE_LOAD                  = "runModuleLoad";
-const std::string Procedures::RUN_MODULE_UNLOAD                = "runModuleUnload";
-const std::string Procedures::RUN_MOVE_ABS_J                   = "runMoveAbsJ";
-const std::string Procedures::RUN_MOVE_J                       = "runMoveJ";
+const std::string Procedures::RUN_CALL_BY_VAR = "runCallByVar";
+const std::string Procedures::RUN_MODULE_LOAD = "runModuleLoad";
+const std::string Procedures::RUN_MODULE_UNLOAD = "runModuleUnload";
+const std::string Procedures::RUN_MOVE_ABS_J = "runMoveAbsJ";
+const std::string Procedures::RUN_MOVE_J = "runMoveJ";
 const std::string Procedures::RUN_MOVE_TO_CALIBRATION_POSITION = "runMoveToCalibrationPosition";
 
 const RAPIDSymbolResource Symbols::EGM_CURRENT_ACTION(Modules::T_ROB_EGM, "current_action");
@@ -95,9 +95,6 @@ const RAPIDSymbolResource Symbols::UTILITY_CALIBRATION_TARGET(Modules::T_ROB_UTI
 const RAPIDSymbolResource Symbols::WATCHDOG_ACTIVE(Modules::T_ROB_WATCHDOG, "active");
 const RAPIDSymbolResource Symbols::WATCHDOG_CHECK_EXTERNAL_STATUS(Modules::T_ROB_WATCHDOG, "check_external_status");
 
-
-
-
 /***********************************************************************************************************************
  * Class definitions: RWSStateMachineInterface::Services::EGM
  */
@@ -111,25 +108,25 @@ EGMActions RWSStateMachineInterface::Services::EGM::getCurrentAction(const std::
   EGMActions result;
   RAPIDNum temp_current_action;
 
-  p_rws_interface_->getRAPIDSymbolData({task, Symbols::EGM_CURRENT_ACTION}, temp_current_action);
-  
-  switch ((int) temp_current_action.value)
+  p_rws_interface_->getRAPIDSymbolData({ task, Symbols::EGM_CURRENT_ACTION }, temp_current_action);
+
+  switch ((int)temp_current_action.value)
   {
     case EGM_ACTION_STOP:
       result = EGM_ACTION_STOP;
-    break;
+      break;
 
     case EGM_ACTION_RUN_JOINT:
       result = EGM_ACTION_RUN_JOINT;
-    break;
+      break;
 
     case EGM_ACTION_RUN_POSE:
       result = EGM_ACTION_RUN_POSE;
-    break;
+      break;
 
     default:
       result = EGM_ACTION_UNKNOWN;
-    break;
+      break;
   }
 
   return result;
@@ -137,12 +134,12 @@ EGMActions RWSStateMachineInterface::Services::EGM::getCurrentAction(const std::
 
 void RWSStateMachineInterface::Services::EGM::getSettings(const std::string& task, EGMSettings* p_settings) const
 {
-  p_rws_interface_->getRAPIDSymbolData({task, Symbols::EGM_SETTINGS}, *p_settings);
+  p_rws_interface_->getRAPIDSymbolData({ task, Symbols::EGM_SETTINGS }, *p_settings);
 }
 
 void RWSStateMachineInterface::Services::EGM::setSettings(const std::string& task, const EGMSettings& settings) const
 {
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::EGM_SETTINGS}, settings);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::EGM_SETTINGS }, settings);
 }
 
 void RWSStateMachineInterface::Services::EGM::signalEGMStartJoint() const
@@ -170,9 +167,6 @@ void RWSStateMachineInterface::Services::EGM::signalEGMStopStream() const
   p_rws_interface_->toggleIOSignal(IOSignals::EGM_STOP_STREAM);
 }
 
-
-
-
 /***********************************************************************************************************************
  * Class definitions: RWSStateMachineInterface::Services::Main
  */
@@ -185,44 +179,39 @@ States RWSStateMachineInterface::Services::Main::getCurrentState(const std::stri
 {
   States result = STATE_UNKNOWN;
   RAPIDNum temp_current_state;
-  p_rws_interface_->getRAPIDSymbolData({task, Symbols::MAIN_CURRENT_STATE}, temp_current_state);
+  p_rws_interface_->getRAPIDSymbolData({ task, Symbols::MAIN_CURRENT_STATE }, temp_current_state);
 
   switch (static_cast<int>(temp_current_state.value))
   {
     case STATE_IDLE:
       result = STATE_IDLE;
-    break;
+      break;
 
     case STATE_INITIALIZE:
       result = STATE_INITIALIZE;
-    break;
+      break;
 
     case STATE_RUN_RAPID_ROUTINE:
       result = STATE_RUN_RAPID_ROUTINE;
-    break;
+      break;
 
     case STATE_RUN_EGM_ROUTINE:
       result = STATE_RUN_EGM_ROUTINE;
-    break;
+      break;
   }
 
   return result;
 }
-
 
 bool RWSStateMachineInterface::Services::Main::isStateIdle(const std::string& task) const
 {
   return getCurrentState(task) == STATE_IDLE;
 }
 
-
 bool RWSStateMachineInterface::Services::Main::isStationary(const std::string& mechanical_unit) const
 {
   return p_rws_interface_->getDigitalSignal(IOSignals::OUTPUT_STATIONARY + "_" + mechanical_unit);
 }
-
-
-
 
 /***********************************************************************************************************************
  * Class definitions: RWSStateMachineInterface::Services::RAPID
@@ -232,14 +221,13 @@ bool RWSStateMachineInterface::Services::Main::isStationary(const std::string& m
  * Primary methods
  */
 
-void RWSStateMachineInterface::Services::RAPID::runCallByVar(const std::string& task,
-                                                             const std::string& routine_name,
+void RWSStateMachineInterface::Services::RAPID::runCallByVar(const std::string& task, const std::string& routine_name,
                                                              const unsigned int routine_number) const
 {
   RAPIDString temp_routine_name(routine_name);
   RAPIDNum temp_routine_number(routine_number);
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::RAPID_CALL_BY_VAR_NAME_INPUT}, temp_routine_name);
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::RAPID_CALL_BY_VAR_NUM_INPUT}, temp_routine_number);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::RAPID_CALL_BY_VAR_NAME_INPUT }, temp_routine_name);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::RAPID_CALL_BY_VAR_NUM_INPUT }, temp_routine_number);
   setRoutineName(task, Procedures::RUN_CALL_BY_VAR);
   signalRunRAPIDRoutine();
 }
@@ -248,7 +236,7 @@ void RWSStateMachineInterface::Services::RAPID::runModuleLoad(const std::string&
                                                               const std::string& file_path) const
 {
   RAPIDString temp_file_path(file_path);
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::RAPID_MODULE_FILE_PATH_INPUT}, temp_file_path);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::RAPID_MODULE_FILE_PATH_INPUT }, temp_file_path);
   setRoutineName(task, Procedures::RUN_MODULE_LOAD);
   signalRunRAPIDRoutine();
 }
@@ -257,7 +245,7 @@ void RWSStateMachineInterface::Services::RAPID::runModuleUnload(const std::strin
                                                                 const std::string& file_path) const
 {
   RAPIDString temp_file_path(file_path);
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::RAPID_MODULE_FILE_PATH_INPUT}, temp_file_path);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::RAPID_MODULE_FILE_PATH_INPUT }, temp_file_path);
   setRoutineName(task, Procedures::RUN_MODULE_UNLOAD);
   signalRunRAPIDRoutine();
 }
@@ -265,14 +253,14 @@ void RWSStateMachineInterface::Services::RAPID::runModuleUnload(const std::strin
 void RWSStateMachineInterface::Services::RAPID::runMoveAbsJ(const std::string& task,
                                                             const JointTarget& joint_target) const
 {
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::RAPID_MOVE_JOINT_TARGET_INPUT}, joint_target);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::RAPID_MOVE_JOINT_TARGET_INPUT }, joint_target);
   setRoutineName(task, Procedures::RUN_MOVE_ABS_J);
   signalRunRAPIDRoutine();
 }
 
 void RWSStateMachineInterface::Services::RAPID::runMoveJ(const std::string& task, const RobTarget& rob_target) const
 {
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::RAPID_MOVE_ROB_TARGET_INPUT}, rob_target);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::RAPID_MOVE_ROB_TARGET_INPUT }, rob_target);
   setRoutineName(task, Procedures::RUN_MOVE_J);
   signalRunRAPIDRoutine();
 }
@@ -285,23 +273,20 @@ void RWSStateMachineInterface::Services::RAPID::runMoveToCalibrationPosition(con
 
 void RWSStateMachineInterface::Services::RAPID::setMoveSpeed(const std::string& task, const SpeedData& speed_data) const
 {
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::RAPID_MOVE_SPEED_INPUT}, speed_data);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::RAPID_MOVE_SPEED_INPUT }, speed_data);
 }
 
 void RWSStateMachineInterface::Services::RAPID::setRoutineName(const std::string& task,
                                                                const std::string& routine_name) const
 {
   RAPIDString temp_routine_name(routine_name);
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::RAPID_ROUTINE_NAME_INPUT}, temp_routine_name);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::RAPID_ROUTINE_NAME_INPUT }, temp_routine_name);
 }
 
 void RWSStateMachineInterface::Services::RAPID::signalRunRAPIDRoutine() const
 {
   p_rws_interface_->toggleIOSignal(IOSignals::RUN_RAPID_ROUTINE);
 }
-
-
-
 
 /***********************************************************************************************************************
  * Class definitions: RWSStateMachineInterface::Services::SG
@@ -633,28 +618,25 @@ void RWSStateMachineInterface::Services::SG::signalRunSGRoutine() const
 
 void RWSStateMachineInterface::Services::SG::getSettings(const std::string& task, SGSettings* p_settings) const
 {
-  p_rws_interface_->getRAPIDSymbolData({task, Symbols::SG_SETTINGS}, *p_settings);
+  p_rws_interface_->getRAPIDSymbolData({ task, Symbols::SG_SETTINGS }, *p_settings);
 }
 
 void RWSStateMachineInterface::Services::SG::setCommandInput(const std::string& task, const SGCommands& command) const
 {
   RAPIDNum temp_command(command);
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::SG_COMMAND_INPUT}, temp_command);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::SG_COMMAND_INPUT }, temp_command);
 }
 
 void RWSStateMachineInterface::Services::SG::setSettings(const std::string& task, const SGSettings& settings) const
 {
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::SG_SETTINGS}, settings);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::SG_SETTINGS }, settings);
 }
 
 void RWSStateMachineInterface::Services::SG::setTargetPositionInput(const std::string& task, const float position) const
 {
   RAPIDNum temp_position(position);
-  p_rws_interface_->setRAPIDSymbolData({task, Symbols::SG_TARGET_POSTION_INPUT}, temp_position);
+  p_rws_interface_->setRAPIDSymbolData({ task, Symbols::SG_TARGET_POSTION_INPUT }, temp_position);
 }
-
-
-
 
 /***********************************************************************************************************************
  * Class definitions: RWSStateMachineInterface::Services::Utility
@@ -666,17 +648,14 @@ void RWSStateMachineInterface::Services::SG::setTargetPositionInput(const std::s
 
 void RWSStateMachineInterface::Services::Utility::getBaseFrame(const std::string& task, Pose* p_base_frame) const
 {
-  p_rws_interface_->getRAPIDSymbolData({task, Symbols::UTILITY_BASE_FRAME}, *p_base_frame);
+  p_rws_interface_->getRAPIDSymbolData({ task, Symbols::UTILITY_BASE_FRAME }, *p_base_frame);
 }
 
 void RWSStateMachineInterface::Services::Utility::getCalibrationTarget(const std::string& task,
                                                                        JointTarget* p_calibration_joint_target) const
 {
-  p_rws_interface_->getRAPIDSymbolData({task, Symbols::UTILITY_CALIBRATION_TARGET}, *p_calibration_joint_target);
+  p_rws_interface_->getRAPIDSymbolData({ task, Symbols::UTILITY_CALIBRATION_TARGET }, *p_calibration_joint_target);
 }
-
-
-
 
 /***********************************************************************************************************************
  * Class definitions: RWSStateMachineInterface::Services::Watchdog
@@ -689,7 +668,7 @@ void RWSStateMachineInterface::Services::Utility::getCalibrationTarget(const std
 bool RWSStateMachineInterface::Services::Watchdog::isActive(const std::string& task) const
 {
   RAPIDBool temp_active;
-  p_rws_interface_->getRAPIDSymbolData({task, Symbols::WATCHDOG_ACTIVE}, temp_active);
+  p_rws_interface_->getRAPIDSymbolData({ task, Symbols::WATCHDOG_ACTIVE }, temp_active);
 
   return temp_active;
 }
@@ -697,7 +676,7 @@ bool RWSStateMachineInterface::Services::Watchdog::isActive(const std::string& t
 bool RWSStateMachineInterface::Services::Watchdog::isCheckingExternalStatus(const std::string& task) const
 {
   RAPIDBool temp_check_external_status;
-  p_rws_interface_->getRAPIDSymbolData({task, Symbols::WATCHDOG_CHECK_EXTERNAL_STATUS}, temp_check_external_status);
+  p_rws_interface_->getRAPIDSymbolData({ task, Symbols::WATCHDOG_CHECK_EXTERNAL_STATUS }, temp_check_external_status);
 
   return temp_check_external_status;
 }
@@ -711,9 +690,6 @@ void RWSStateMachineInterface::Services::Watchdog::signalStopRequest() const
 {
   p_rws_interface_->toggleIOSignal(IOSignals::WD_STOP_REQUEST);
 }
-
-
-
 
 /***********************************************************************************************************************
  * Class definitions: RWSStateMachineInterface
@@ -752,5 +728,5 @@ void RWSStateMachineInterface::toggleIOSignal(const std::string& iosignal)
     throw std::runtime_error("RWSStateMachineInterface::toggleIOSignal() failed");
 }
 
-} // end namespace rws
-} // end namespace abb
+}  // end namespace rws
+}  // end namespace abb

--- a/src/rws_subscription.cpp
+++ b/src/rws_subscription.cpp
@@ -8,184 +8,163 @@
 
 #include <iostream>
 
-
-namespace abb :: rws
+namespace abb ::rws
 {
-  using namespace Poco::Net;
+using namespace Poco::Net;
 
+SubscriptionGroup::SubscriptionGroup(SubscriptionManager& subscription_manager, SubscriptionResources const& resources)
+  : subscription_manager_{ subscription_manager }
+  , subscription_group_id_{ subscription_manager.openSubscription(getURI(subscription_manager, resources)) }
+{
+}
 
-  SubscriptionGroup::SubscriptionGroup(SubscriptionManager& subscription_manager, SubscriptionResources const& resources)
-  : subscription_manager_ {subscription_manager}
-  , subscription_group_id_ {subscription_manager.openSubscription(getURI(subscription_manager, resources))}
+SubscriptionGroup::SubscriptionGroup(SubscriptionGroup&& rhs)
+  : subscription_manager_{ rhs.subscription_manager_ }, subscription_group_id_{ rhs.subscription_group_id_ }
+{
+  // Clear subscription_group_id_ of the SubscriptionGroup that has been moved from,
+  // s.t. its destructor does not close the subscription.
+  rhs.subscription_group_id_.clear();
+}
+
+SubscriptionGroup::~SubscriptionGroup()
+{
+  close();
+}
+
+void SubscriptionGroup::close()
+{
+  if (!subscription_group_id_.empty())
   {
-  }
-
-
-  SubscriptionGroup::SubscriptionGroup(SubscriptionGroup&& rhs)
-  : subscription_manager_ {rhs.subscription_manager_}
-  , subscription_group_id_ {rhs.subscription_group_id_}
-  {
-    // Clear subscription_group_id_ of the SubscriptionGroup that has been moved from,
-    // s.t. its destructor does not close the subscription.
-    rhs.subscription_group_id_.clear();
-  }
-
-
-  SubscriptionGroup::~SubscriptionGroup()
-  {
-    close();
-  }
-
-
-  void SubscriptionGroup::close()
-  {
-    if (!subscription_group_id_.empty())
-    {
-      subscription_manager_.closeSubscription(subscription_group_id_);
-      subscription_group_id_.clear();
-    }
-  }
-
-
-  void SubscriptionGroup::detach() noexcept
-  {
+    subscription_manager_.closeSubscription(subscription_group_id_);
     subscription_group_id_.clear();
   }
+}
 
+void SubscriptionGroup::detach() noexcept
+{
+  subscription_group_id_.clear();
+}
 
-  SubscriptionReceiver SubscriptionGroup::receive() const
+SubscriptionReceiver SubscriptionGroup::receive() const
+{
+  return SubscriptionReceiver{ subscription_manager_, subscription_group_id_ };
+}
+
+std::vector<std::pair<std::string, SubscriptionPriority>>
+SubscriptionGroup::getURI(SubscriptionManager& subscription_manager, SubscriptionResources const& resources)
+{
+  std::vector<std::pair<std::string, SubscriptionPriority>> uri;
+  uri.reserve(resources.size());
+
+  for (auto&& r : resources)
+    uri.emplace_back(r.getURI(subscription_manager), r.getPriority());
+
+  return uri;
+}
+
+const std::chrono::microseconds SubscriptionReceiver::DEFAULT_SUBSCRIPTION_TIMEOUT{ 40000000000 };
+
+SubscriptionReceiver::SubscriptionReceiver(SubscriptionManager& subscription_manager,
+                                           std::string const& subscription_group_id)
+  : subscription_manager_{ subscription_manager }
+  , webSocket_{ subscription_manager_.receiveSubscription(subscription_group_id) }
+{
+}
+
+SubscriptionReceiver::~SubscriptionReceiver()
+{
+}
+
+bool SubscriptionReceiver::waitForEvent(SubscriptionCallback& callback, std::chrono::microseconds timeout)
+{
+  WebSocketFrame frame;
+  if (webSocketReceiveFrame(frame, timeout))
   {
-    return SubscriptionReceiver {subscription_manager_, subscription_group_id_};
+    Poco::AutoPtr<Poco::XML::Document> doc = parser_.parseString(frame.frame_content);
+    subscription_manager_.processEvent(doc, callback);
+    return true;
   }
 
+  return false;
+}
 
-  std::vector<std::pair<std::string, SubscriptionPriority>> SubscriptionGroup::getURI(
-      SubscriptionManager& subscription_manager, SubscriptionResources const& resources)
+bool SubscriptionReceiver::webSocketReceiveFrame(WebSocketFrame& frame, std::chrono::microseconds timeout)
+{
+  auto now = std::chrono::steady_clock::now();
+  auto deadline = std::chrono::steady_clock::now() + timeout;
+
+  // If the connection is still active...
+  int flags = 0;
+  std::string content;
+  int number_of_bytes_received = 0;
+
+  // Wait for (non-ping) WebSocket frames.
+  do
   {
-    std::vector<std::pair<std::string, SubscriptionPriority>> uri;
-    uri.reserve(resources.size());
+    now = std::chrono::steady_clock::now();
+    if (now >= deadline)
+      BOOST_THROW_EXCEPTION(TimeoutError{ "WebSocket frame receive timeout" });
 
-    for (auto&& r : resources)
-      uri.emplace_back(r.getURI(subscription_manager), r.getPriority());
+    webSocket_.setReceiveTimeout(std::chrono::duration_cast<std::chrono::microseconds>(deadline - now).count());
+    flags = 0;
 
-    return uri;
-  }
-
-
-  const std::chrono::microseconds SubscriptionReceiver::DEFAULT_SUBSCRIPTION_TIMEOUT {40000000000};
-
-
-  SubscriptionReceiver::SubscriptionReceiver(SubscriptionManager& subscription_manager, std::string const& subscription_group_id)
-  : subscription_manager_ {subscription_manager}
-  , webSocket_ {subscription_manager_.receiveSubscription(subscription_group_id)}
-  {
-  }
-
-
-  SubscriptionReceiver::~SubscriptionReceiver()
-  {
-  }
-
-
-  bool SubscriptionReceiver::waitForEvent(SubscriptionCallback& callback, std::chrono::microseconds timeout)
-  {
-    WebSocketFrame frame;
-    if (webSocketReceiveFrame(frame, timeout))
+    try
     {
-      Poco::AutoPtr<Poco::XML::Document> doc = parser_.parseString(frame.frame_content);
-      subscription_manager_.processEvent(doc, callback);
-      return true;
+      number_of_bytes_received = webSocket_.receiveFrame(websocket_buffer_, sizeof(websocket_buffer_), flags);
     }
+    catch (Poco::TimeoutException const&)
+    {
+      BOOST_THROW_EXCEPTION(TimeoutError{ "WebSocket frame receive timeout" }
+                            << boost::errinfo_nested_exception(boost::current_exception()));
+    }
+
+    content = std::string(websocket_buffer_, number_of_bytes_received);
+
+    // Check for ping frame.
+    if ((flags & WebSocket::FRAME_OP_BITMASK) == WebSocket::FRAME_OP_PING)
+    {
+      // Reply with a pong frame.
+      webSocket_.sendFrame(websocket_buffer_, number_of_bytes_received,
+                           WebSocket::FRAME_FLAG_FIN | WebSocket::FRAME_OP_PONG);
+    }
+  } while ((flags & WebSocket::FRAME_OP_BITMASK) == WebSocket::FRAME_OP_PING);
+
+  // Check for closing frame.
+  if ((flags & WebSocket::FRAME_OP_BITMASK) == WebSocket::FRAME_OP_CLOSE)
+  {
+    // Do not pass content of a closing frame to end user,
+    // according to "The WebSocket Protocol" RFC6455.
+    frame.frame_content.clear();
+    frame.flags = flags;
 
     return false;
   }
 
+  frame.flags = flags;
+  frame.frame_content = content;
 
-  bool SubscriptionReceiver::webSocketReceiveFrame(WebSocketFrame& frame, std::chrono::microseconds timeout)
-  {
-    auto now = std::chrono::steady_clock::now();
-    auto deadline = std::chrono::steady_clock::now() + timeout;
-
-    // If the connection is still active...
-    int flags = 0;
-    std::string content;
-    int number_of_bytes_received = 0;
-
-    // Wait for (non-ping) WebSocket frames.
-    do
-    {
-      now = std::chrono::steady_clock::now();
-      if (now >= deadline)
-        BOOST_THROW_EXCEPTION(TimeoutError {"WebSocket frame receive timeout"});
-
-      webSocket_.setReceiveTimeout(std::chrono::duration_cast<std::chrono::microseconds>(deadline - now).count());
-      flags = 0;
-
-      try
-      {
-        number_of_bytes_received = webSocket_.receiveFrame(websocket_buffer_, sizeof(websocket_buffer_), flags);
-      }
-      catch (Poco::TimeoutException const&)
-      {
-        BOOST_THROW_EXCEPTION(
-          TimeoutError {"WebSocket frame receive timeout"}
-            << boost::errinfo_nested_exception(boost::current_exception())
-        );
-      }
-
-      content = std::string(websocket_buffer_, number_of_bytes_received);
-
-      // Check for ping frame.
-      if ((flags & WebSocket::FRAME_OP_BITMASK) == WebSocket::FRAME_OP_PING)
-      {
-        // Reply with a pong frame.
-        webSocket_.sendFrame(websocket_buffer_,
-                                number_of_bytes_received,
-                                WebSocket::FRAME_FLAG_FIN | WebSocket::FRAME_OP_PONG);
-      }
-    } while ((flags & WebSocket::FRAME_OP_BITMASK) == WebSocket::FRAME_OP_PING);
-
-    // Check for closing frame.
-    if ((flags & WebSocket::FRAME_OP_BITMASK) == WebSocket::FRAME_OP_CLOSE)
-    {
-      // Do not pass content of a closing frame to end user,
-      // according to "The WebSocket Protocol" RFC6455.
-      frame.frame_content.clear();
-      frame.flags = flags;
-
-      return false;
-    }
-
-    frame.flags = flags;
-    frame.frame_content = content;
-
-    return number_of_bytes_received != 0;
-  }
-
-
-  void SubscriptionReceiver::shutdown()
-  {
-    // Shut down the socket. This should make webSocketReceiveFrame() return as soon as possible.
-    webSocket_.shutdown();
-  }
-
-
-  void SubscriptionCallback::processEvent(IOSignalStateEvent const& event)
-  {
-  }
-
-
-  void SubscriptionCallback::processEvent(RAPIDExecutionStateEvent const& event)
-  {
-  }
-
-
-  void SubscriptionCallback::processEvent(ControllerStateEvent const& event)
-  {
-  }
-
-
-  void SubscriptionCallback::processEvent(OperationModeEvent const& event)
-  {
-  }
+  return number_of_bytes_received != 0;
 }
+
+void SubscriptionReceiver::shutdown()
+{
+  // Shut down the socket. This should make webSocketReceiveFrame() return as soon as possible.
+  webSocket_.shutdown();
+}
+
+void SubscriptionCallback::processEvent(IOSignalStateEvent const& event)
+{
+}
+
+void SubscriptionCallback::processEvent(RAPIDExecutionStateEvent const& event)
+{
+}
+
+void SubscriptionCallback::processEvent(ControllerStateEvent const& event)
+{
+}
+
+void SubscriptionCallback::processEvent(OperationModeEvent const& event)
+{
+}
+}  // namespace abb::rws

--- a/src/rws_websocket.cpp
+++ b/src/rws_websocket.cpp
@@ -2,46 +2,45 @@
 
 #include <Poco/Net/WebSocket.h>
 
-
-namespace abb :: rws
+namespace abb ::rws
 {
-  std::string mapWebSocketOpcode(int flags)
+std::string mapWebSocketOpcode(int flags)
+{
+  using Poco::Net::WebSocket;
+
+  std::string result;
+
+  switch (flags & WebSocket::FRAME_OP_BITMASK)
   {
-    using Poco::Net::WebSocket;
-
-    std::string result;
-
-    switch (flags & WebSocket::FRAME_OP_BITMASK)
-    {
-      case WebSocket::FRAME_OP_CONT:
-        result = "FRAME_OP_CONT";
+    case WebSocket::FRAME_OP_CONT:
+      result = "FRAME_OP_CONT";
       break;
 
-      case WebSocket::FRAME_OP_TEXT:
-        result = "FRAME_OP_TEXT";
+    case WebSocket::FRAME_OP_TEXT:
+      result = "FRAME_OP_TEXT";
       break;
 
-      case WebSocket::FRAME_OP_BINARY:
-        result = "FRAME_OP_BINARY";
+    case WebSocket::FRAME_OP_BINARY:
+      result = "FRAME_OP_BINARY";
       break;
 
-      case WebSocket::FRAME_OP_CLOSE:
-        result = "FRAME_OP_CLOSE";
+    case WebSocket::FRAME_OP_CLOSE:
+      result = "FRAME_OP_CLOSE";
       break;
 
-      case WebSocket::FRAME_OP_PING:
-        result = "FRAME_OP_PING";
+    case WebSocket::FRAME_OP_PING:
+      result = "FRAME_OP_PING";
       break;
 
-      case WebSocket::FRAME_OP_PONG:
-        result = "FRAME_OP_PONG";
+    case WebSocket::FRAME_OP_PONG:
+      result = "FRAME_OP_PONG";
       break;
 
-      default:
-        result = "FRAME_OP_UNDEFINED";
+    default:
+      result = "FRAME_OP_UNDEFINED";
       break;
-    }
-
-    return result;
   }
+
+  return result;
 }
+}  // namespace abb::rws

--- a/src/system_constants.cpp
+++ b/src/system_constants.cpp
@@ -36,7 +36,6 @@
 
 #include <abb_librws/system_constants.h>
 
-
 namespace abb
 {
 namespace rws
@@ -45,50 +44,50 @@ namespace rws
  * Struct definitions: SystemConstants
  */
 
-const std::string SystemConstants::ContollerStates::CONTROLLER_MOTOR_ON       = "motoron";
-const std::string SystemConstants::ContollerStates::CONTROLLER_MOTOR_OFF      = "motoroff";
+const std::string SystemConstants::ContollerStates::CONTROLLER_MOTOR_ON = "motoron";
+const std::string SystemConstants::ContollerStates::CONTROLLER_MOTOR_OFF = "motoroff";
 const std::string SystemConstants::ContollerStates::PANEL_OPERATION_MODE_AUTO = "AUTO";
-const std::string SystemConstants::ContollerStates::RAPID_EXECUTION_RUNNING   = "running";
+const std::string SystemConstants::ContollerStates::RAPID_EXECUTION_RUNNING = "running";
 
-const std::string SystemConstants::General::EXTERNAL_APPLICATION   = "ExternalApplication";
-const std::string SystemConstants::General::EXTERNAL_LOCATION      = "ExternalLocation";
+const std::string SystemConstants::General::EXTERNAL_APPLICATION = "ExternalApplication";
+const std::string SystemConstants::General::EXTERNAL_LOCATION = "ExternalLocation";
 const unsigned short SystemConstants::General::DEFAULT_PORT_NUMBER = 80;
-const std::string SystemConstants::General::DEFAULT_PASSWORD       = "robotics";
-const std::string SystemConstants::General::DEFAULT_USERNAME       = "Default User";
-const std::string SystemConstants::General::LOCAL                  = "local";
-const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_1  = "ROB_1";
-const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_2  = "ROB_2";
-const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_3  = "ROB_3";
-const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_4  = "ROB_4";
-const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_L  = "ROB_L";
-const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_R  = "ROB_R";
-const std::string SystemConstants::General::REMOTE                 = "remote";
-const std::string SystemConstants::General::COORDINATE_BASE        = "Base";
-const std::string SystemConstants::General::COORDINATE_WORLD       = "Word";
-const std::string SystemConstants::General::COORDINATE_TOOL        = "Tool";
-const std::string SystemConstants::General::COORDINATE_WOBJ        = "Wobj";
+const std::string SystemConstants::General::DEFAULT_PASSWORD = "robotics";
+const std::string SystemConstants::General::DEFAULT_USERNAME = "Default User";
+const std::string SystemConstants::General::LOCAL = "local";
+const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_1 = "ROB_1";
+const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_2 = "ROB_2";
+const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_3 = "ROB_3";
+const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_4 = "ROB_4";
+const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_L = "ROB_L";
+const std::string SystemConstants::General::MECHANICAL_UNIT_ROB_R = "ROB_R";
+const std::string SystemConstants::General::REMOTE = "remote";
+const std::string SystemConstants::General::COORDINATE_BASE = "Base";
+const std::string SystemConstants::General::COORDINATE_WORLD = "Word";
+const std::string SystemConstants::General::COORDINATE_TOOL = "Tool";
+const std::string SystemConstants::General::COORDINATE_WOBJ = "Wobj";
 
-const std::string SystemConstants::IOSignals::HAND_ACTUAL_POSITION_L   = "hand_ActualPosition_L";
-const std::string SystemConstants::IOSignals::HAND_ACTUAL_POSITION_R   = "hand_ActualPosition_R";
-const std::string SystemConstants::IOSignals::HAND_ACTUAL_SPEED_L      = "hand_ActualSpeed_L";
-const std::string SystemConstants::IOSignals::HAND_ACTUAL_SPEED_R      = "hand_ActualSpeed_R";
+const std::string SystemConstants::IOSignals::HAND_ACTUAL_POSITION_L = "hand_ActualPosition_L";
+const std::string SystemConstants::IOSignals::HAND_ACTUAL_POSITION_R = "hand_ActualPosition_R";
+const std::string SystemConstants::IOSignals::HAND_ACTUAL_SPEED_L = "hand_ActualSpeed_L";
+const std::string SystemConstants::IOSignals::HAND_ACTUAL_SPEED_R = "hand_ActualSpeed_R";
 const std::string SystemConstants::IOSignals::HAND_STATUS_CALIBRATED_L = "hand_StatusCalibrated_L";
 const std::string SystemConstants::IOSignals::HAND_STATUS_CALIBRATED_R = "hand_StatusCalibrated_R";
-const std::string SystemConstants::IOSignals::HIGH                     = "1";
-const std::string SystemConstants::IOSignals::LOW                      = "0";
+const std::string SystemConstants::IOSignals::HIGH = "1";
+const std::string SystemConstants::IOSignals::LOW = "0";
 
 const std::string SystemConstants::RAPID::RAPID_FALSE = "FALSE";
-const std::string SystemConstants::RAPID::RAPID_TRUE  = "TRUE";
-const std::string SystemConstants::RAPID::TASK_ROB_1  = "T_ROB1";
-const std::string SystemConstants::RAPID::TASK_ROB_2  = "T_ROB2";
-const std::string SystemConstants::RAPID::TASK_ROB_3  = "T_ROB3";
-const std::string SystemConstants::RAPID::TASK_ROB_4  = "T_ROB4";
-const std::string SystemConstants::RAPID::TASK_ROB_L  = "T_ROB_L";
-const std::string SystemConstants::RAPID::TASK_ROB_R  = "T_ROB_R";
-const std::string SystemConstants::RAPID::TYPE_BOOL   = "bool";
-const std::string SystemConstants::RAPID::TYPE_DNUM   = "dnum";
-const std::string SystemConstants::RAPID::TYPE_NUM    = "num";
+const std::string SystemConstants::RAPID::RAPID_TRUE = "TRUE";
+const std::string SystemConstants::RAPID::TASK_ROB_1 = "T_ROB1";
+const std::string SystemConstants::RAPID::TASK_ROB_2 = "T_ROB2";
+const std::string SystemConstants::RAPID::TASK_ROB_3 = "T_ROB3";
+const std::string SystemConstants::RAPID::TASK_ROB_4 = "T_ROB4";
+const std::string SystemConstants::RAPID::TASK_ROB_L = "T_ROB_L";
+const std::string SystemConstants::RAPID::TASK_ROB_R = "T_ROB_R";
+const std::string SystemConstants::RAPID::TYPE_BOOL = "bool";
+const std::string SystemConstants::RAPID::TYPE_DNUM = "dnum";
+const std::string SystemConstants::RAPID::TYPE_NUM = "num";
 const std::string SystemConstants::RAPID::TYPE_STRING = "string";
 
-} // end namespace rws
-} // end namespace abb
+}  // end namespace rws
+}  // end namespace abb

--- a/src/v1_0/rw/io.cpp
+++ b/src/v1_0/rw/io.cpp
@@ -3,121 +3,109 @@
 
 #include <boost/throw_exception.hpp>
 
-
-namespace abb :: rws :: v1_0 :: rw :: io
+namespace abb ::rws ::v1_0 ::rw ::io
 {
-    static std::string generateIOSignalPath(const std::string& iosignal);
-    static bool digitalSignalToBool(std::string const& value);
+static std::string generateIOSignalPath(const std::string& iosignal);
+static bool digitalSignalToBool(std::string const& value);
 
+IOSignalInfo getIOSignals(RWSClient& client)
+{
+  auto const doc = parseXml(client.httpGet(Resources::RW_IOSYSTEM_SIGNALS).content());
 
-    IOSignalInfo getIOSignals(RWSClient& client)
+  IOSignalInfo signals;
+
+  for (auto&& node : xmlFindNodes(doc, { "class", "ios-signal-li" }))
+  {
+    std::string const name = xmlFindTextContent(node, { "class", "name" });
+    std::string const value = xmlFindTextContent(node, { "class", "lvalue" });
+    std::string const type = xmlFindTextContent(node, { "class", "type" });
+
+    if (!name.empty() && !value.empty())
     {
-        auto const doc = parseXml(client.httpGet(Resources::RW_IOSYSTEM_SIGNALS).content());
-
-        IOSignalInfo signals;
-
-        for (auto&& node : xmlFindNodes(doc, {"class", "ios-signal-li"}))
-        {
-            std::string const name = xmlFindTextContent(node, {"class", "name"});
-            std::string const value = xmlFindTextContent(node, {"class", "lvalue"});
-            std::string const type = xmlFindTextContent(node, {"class", "type"});
-
-            if (!name.empty() && !value.empty())
-            {
-                if (type == "DI" || type == "DO")
-                    signals[name] = digitalSignalToBool(value);
-                else if (type == "AI" || type == "AO")
-                    signals[name] = std::stof(value);
-            }
-        }
-
-        return signals;
+      if (type == "DI" || type == "DO")
+        signals[name] = digitalSignalToBool(value);
+      else if (type == "AI" || type == "AO")
+        signals[name] = std::stof(value);
     }
+  }
 
-
-    bool getDigitalSignal(RWSClient& client, std::string const& signal_name)
-    {
-        return digitalSignalToBool(getIOSignal(client, signal_name));
-    }
-
-
-    float getAnalogSignal(RWSClient& client, std::string const& signal_name)
-    {
-        return std::stof(getIOSignal(client, signal_name));
-    }
-
-
-    std::uint32_t getGroupSignal(RWSClient& client, std::string const& signal_name)
-    {
-        return std::stoul(getIOSignal(client, signal_name));
-    }
-
-
-    void setDigitalSignal(RWSClient& client, std::string const& signal_name, bool value)
-    {
-        setIOSignal(client, signal_name, value ? SystemConstants::IOSignals::HIGH : SystemConstants::IOSignals::LOW);
-    }
-
-
-    void setAnalogSignal(RWSClient& client, std::string const& signal_name, float value)
-    {
-        std::stringstream str;
-        str << std::setprecision(SINGLE_PRECISION_DIGITS) << value;
-        setIOSignal(client, signal_name, str.str());
-    }
-
-
-    void setGroupSignal(RWSClient& client, std::string const& signal_name, std::uint32_t value)
-    {
-        setIOSignal(client, signal_name, std::to_string(value));
-    }
-
-
-    std::string getIOSignal(RWSClient& client, const std::string& iosignal)
-    {
-        try
-        {
-            std::string const uri = generateIOSignalPath(iosignal);
-            auto const rws_result = parseXml(client.httpGet(uri).content());
-
-            return xmlFindTextContent(rws_result, XMLAttributes::CLASS_LVALUE);
-        }
-        catch (boost::exception& e)
-        {
-            e << IoSignalErrorInfo {iosignal};
-            throw;
-        }
-    }
-
-
-    void setIOSignal(RWSClient& client, const std::string& iosignal, const std::string& value)
-    {
-        try
-        {
-            std::string uri = generateIOSignalPath(iosignal) + "?" + Queries::ACTION_SET;
-            std::string content = Identifiers::LVALUE + "=" + value;
-
-            client.httpPost(uri, content);
-        }
-        catch (boost::exception& e)
-        {
-            e << IoSignalErrorInfo {iosignal};
-            throw;
-        }
-    }
-
-
-    static std::string generateIOSignalPath(const std::string& iosignal)
-    {
-        return Resources::RW_IOSYSTEM_SIGNALS + "/" + iosignal;
-    }
-
-
-    static bool digitalSignalToBool(std::string const& value)
-    {
-        if (value != SystemConstants::IOSignals::HIGH && value != SystemConstants::IOSignals::LOW)
-            BOOST_THROW_EXCEPTION(std::logic_error {"Unexpected value \"" + value + "\" of a digital signal"});
-
-        return value == SystemConstants::IOSignals::HIGH;
-    }
+  return signals;
 }
+
+bool getDigitalSignal(RWSClient& client, std::string const& signal_name)
+{
+  return digitalSignalToBool(getIOSignal(client, signal_name));
+}
+
+float getAnalogSignal(RWSClient& client, std::string const& signal_name)
+{
+  return std::stof(getIOSignal(client, signal_name));
+}
+
+std::uint32_t getGroupSignal(RWSClient& client, std::string const& signal_name)
+{
+  return std::stoul(getIOSignal(client, signal_name));
+}
+
+void setDigitalSignal(RWSClient& client, std::string const& signal_name, bool value)
+{
+  setIOSignal(client, signal_name, value ? SystemConstants::IOSignals::HIGH : SystemConstants::IOSignals::LOW);
+}
+
+void setAnalogSignal(RWSClient& client, std::string const& signal_name, float value)
+{
+  std::stringstream str;
+  str << std::setprecision(SINGLE_PRECISION_DIGITS) << value;
+  setIOSignal(client, signal_name, str.str());
+}
+
+void setGroupSignal(RWSClient& client, std::string const& signal_name, std::uint32_t value)
+{
+  setIOSignal(client, signal_name, std::to_string(value));
+}
+
+std::string getIOSignal(RWSClient& client, const std::string& iosignal)
+{
+  try
+  {
+    std::string const uri = generateIOSignalPath(iosignal);
+    auto const rws_result = parseXml(client.httpGet(uri).content());
+
+    return xmlFindTextContent(rws_result, XMLAttributes::CLASS_LVALUE);
+  }
+  catch (boost::exception& e)
+  {
+    e << IoSignalErrorInfo{ iosignal };
+    throw;
+  }
+}
+
+void setIOSignal(RWSClient& client, const std::string& iosignal, const std::string& value)
+{
+  try
+  {
+    std::string uri = generateIOSignalPath(iosignal) + "?" + Queries::ACTION_SET;
+    std::string content = Identifiers::LVALUE + "=" + value;
+
+    client.httpPost(uri, content);
+  }
+  catch (boost::exception& e)
+  {
+    e << IoSignalErrorInfo{ iosignal };
+    throw;
+  }
+}
+
+static std::string generateIOSignalPath(const std::string& iosignal)
+{
+  return Resources::RW_IOSYSTEM_SIGNALS + "/" + iosignal;
+}
+
+static bool digitalSignalToBool(std::string const& value)
+{
+  if (value != SystemConstants::IOSignals::HIGH && value != SystemConstants::IOSignals::LOW)
+    BOOST_THROW_EXCEPTION(std::logic_error{ "Unexpected value \"" + value + "\" of a digital signal" });
+
+  return value == SystemConstants::IOSignals::HIGH;
+}
+}  // namespace abb::rws::v1_0::rw::io

--- a/src/v1_0/rw/panel.cpp
+++ b/src/v1_0/rw/panel.cpp
@@ -3,71 +3,66 @@
 #include <abb_librws/parsing.h>
 #include <abb_librws/system_constants.h>
 
-
-namespace abb :: rws :: v1_0 :: rw :: panel
+namespace abb ::rws ::v1_0 ::rw ::panel
 {
-    ControllerState getControllerState(RWSClient& client)
-    {
-        std::string uri = Resources::RW_PANEL_CTRLSTATE;
-        RWSResult xml_content = parseXml(client.httpGet(uri).content());
+ControllerState getControllerState(RWSClient& client)
+{
+  std::string uri = Resources::RW_PANEL_CTRLSTATE;
+  RWSResult xml_content = parseXml(client.httpGet(uri).content());
 
-        Poco::XML::Node const * li_node = xml_content->getNodeByPath("html/body/div/ul/li");
-        if (!li_node)
-            BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS response: can't find XML path html/body/div/ul/li"});
+  Poco::XML::Node const* li_node = xml_content->getNodeByPath("html/body/div/ul/li");
+  if (!li_node)
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS response: can't find XML path html/body/div/ul/li" });
 
-        std::string const ctrlstate = xmlFindTextContent(li_node, XMLAttributes::CLASS_CTRLSTATE);
-        if (ctrlstate.empty())
-            BOOST_THROW_EXCEPTION(ProtocolError {"Can't find a node with class=\"ctrlstate\""});
+  std::string const ctrlstate = xmlFindTextContent(li_node, XMLAttributes::CLASS_CTRLSTATE);
+  if (ctrlstate.empty())
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Can't find a node with class=\"ctrlstate\"" });
 
-        return makeControllerState(ctrlstate);
-    }
-
-
-    OperationMode getOperationMode(RWSClient& client)
-    {
-        std::string uri = Resources::RW_PANEL_OPMODE;
-        RWSResult xml_content = parseXml(client.httpGet(uri).content());
-
-        Poco::XML::Node const * li_node = xml_content->getNodeByPath("html/body/div/ul/li");
-        if (!li_node)
-            BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS response: can't find XML path html/body/div/ul/li"});
-
-        std::string const opmode = xmlFindTextContent(li_node, XMLAttributes::CLASS_OPMODE);
-        if (opmode.empty())
-            BOOST_THROW_EXCEPTION(ProtocolError {"Can't find a node with class=\"opmode\""});
-
-        return makeOperationMode(opmode);
-    }
-
-
-    void setControllerState(RWSClient& client, ControllerState state)
-    {
-        std::string uri = Resources::RW_PANEL_CTRLSTATE + "?" + Queries::ACTION_SETCTRLSTATE;
-        std::stringstream content;
-        content << "ctrl-state=" << state;
-
-        client.httpPost(uri, content.str());
-    }
-
-
-    unsigned getSpeedRatio(RWSClient& client)
-    {
-        std::string uri = "/rw/panel/speedratio";
-        RWSResult rws_result = parseXml(client.httpGet(uri).content());
-
-        return std::stoul(xmlFindTextContent(rws_result, XMLAttribute(Identifiers::CLASS, "speedratio")));
-    }
-
-
-    void setSpeedRatio(RWSClient& client, unsigned int ratio)
-    {
-        if (ratio > 100)
-            BOOST_THROW_EXCEPTION(std::out_of_range {"Speed ratio argument out of range (should be 0 <= ratio <= 100)"});
-
-        std::string uri = "/rw/panel/speedratio?action=setspeedratio";
-        std::stringstream content;
-        content << "speed-ratio=" << ratio;
-
-        client.httpPost(uri, content.str());
-    }
+  return makeControllerState(ctrlstate);
 }
+
+OperationMode getOperationMode(RWSClient& client)
+{
+  std::string uri = Resources::RW_PANEL_OPMODE;
+  RWSResult xml_content = parseXml(client.httpGet(uri).content());
+
+  Poco::XML::Node const* li_node = xml_content->getNodeByPath("html/body/div/ul/li");
+  if (!li_node)
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS response: can't find XML path html/body/div/ul/li" });
+
+  std::string const opmode = xmlFindTextContent(li_node, XMLAttributes::CLASS_OPMODE);
+  if (opmode.empty())
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Can't find a node with class=\"opmode\"" });
+
+  return makeOperationMode(opmode);
+}
+
+void setControllerState(RWSClient& client, ControllerState state)
+{
+  std::string uri = Resources::RW_PANEL_CTRLSTATE + "?" + Queries::ACTION_SETCTRLSTATE;
+  std::stringstream content;
+  content << "ctrl-state=" << state;
+
+  client.httpPost(uri, content.str());
+}
+
+unsigned getSpeedRatio(RWSClient& client)
+{
+  std::string uri = "/rw/panel/speedratio";
+  RWSResult rws_result = parseXml(client.httpGet(uri).content());
+
+  return std::stoul(xmlFindTextContent(rws_result, XMLAttribute(Identifiers::CLASS, "speedratio")));
+}
+
+void setSpeedRatio(RWSClient& client, unsigned int ratio)
+{
+  if (ratio > 100)
+    BOOST_THROW_EXCEPTION(std::out_of_range{ "Speed ratio argument out of range (should be 0 <= ratio <= 100)" });
+
+  std::string uri = "/rw/panel/speedratio?action=setspeedratio";
+  std::stringstream content;
+  content << "speed-ratio=" << ratio;
+
+  client.httpPost(uri, content.str());
+}
+}  // namespace abb::rws::v1_0::rw::panel

--- a/src/v1_0/rw/rapid.cpp
+++ b/src/v1_0/rw/rapid.cpp
@@ -3,240 +3,221 @@
 #include <abb_librws/parsing.h>
 #include <abb_librws/system_constants.h>
 
-
-namespace abb :: rws :: v1_0 :: rw :: rapid
+namespace abb ::rws ::v1_0 ::rw ::rapid
 {
-    /**
-     * \brief A method for retrieving the properties of a RAPID symbol.
-     *
-     * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
-     *
-     * \return RWSResult containing the result.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    static RWSResult getRAPIDSymbolProperties(RWSClient& client, RAPIDResource const& resource);
+/**
+ * \brief A method for retrieving the properties of a RAPID symbol.
+ *
+ * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
+ *
+ * \return RWSResult containing the result.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+static RWSResult getRAPIDSymbolProperties(RWSClient& client, RAPIDResource const& resource);
 
-    /**
-     * \brief Method for generating a RAPID data resource URI path.
-     *
-     * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
-     *
-     * \return std::string containing the path.
-     */
-    static std::string generateRAPIDDataPath(const RAPIDResource& resource);
+/**
+ * \brief Method for generating a RAPID data resource URI path.
+ *
+ * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
+ *
+ * \return std::string containing the path.
+ */
+static std::string generateRAPIDDataPath(const RAPIDResource& resource);
 
-    /**
-     * \brief Method for generating a RAPID properties resource URI path.
-     *
-     * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
-     *
-     * \return std::string containing the path.
-     */
-    static std::string generateRAPIDPropertiesPath(const RAPIDResource& resource);
+/**
+ * \brief Method for generating a RAPID properties resource URI path.
+ *
+ * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
+ *
+ * \return std::string containing the path.
+ */
+static std::string generateRAPIDPropertiesPath(const RAPIDResource& resource);
 
-    /**
-     * \brief Method for generating a task resource URI path.
-     *
-     * \param task for the task name.
-     *
-     * \return std::string containing the path.
-     */
-    static std::string generateRAPIDTasksPath(const std::string& task);
+/**
+ * \brief Method for generating a task resource URI path.
+ *
+ * \param task for the task name.
+ *
+ * \return std::string containing the path.
+ */
+static std::string generateRAPIDTasksPath(const std::string& task);
 
+RAPIDExecutionInfo getRAPIDExecution(RWSClient& client)
+{
+  RAPIDExecutionInfo result;
 
-    RAPIDExecutionInfo getRAPIDExecution(RWSClient& client)
-    {
-        RAPIDExecutionInfo result;
+  std::string const uri = Resources::RW_RAPID_EXECUTION;
+  RWSResult xml_content = parseXml(client.httpGet(uri).content());
 
-        std::string const uri = Resources::RW_RAPID_EXECUTION;
-        RWSResult xml_content = parseXml(client.httpGet(uri).content());
+  Poco::XML::Node const* li_node = xml_content->getNodeByPath("html/body/div/ul/li");
+  if (!li_node)
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS response: can't find XML path html/body/div/ul/li" });
 
-        Poco::XML::Node const * li_node = xml_content->getNodeByPath("html/body/div/ul/li");
-        if (!li_node)
-            BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS response: can't find XML path html/body/div/ul/li"});
+  std::string const ctrlexecstate = xmlFindTextContent(li_node, XMLAttributes::CLASS_CTRLEXECSTATE);
+  if (ctrlexecstate.empty())
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Can't find a node with class=\"ctrlexecstate\"" });
 
-        std::string const ctrlexecstate = xmlFindTextContent(li_node, XMLAttributes::CLASS_CTRLEXECSTATE);
-        if (ctrlexecstate.empty())
-            BOOST_THROW_EXCEPTION(ProtocolError {"Can't find a node with class=\"ctrlexecstate\""});
+  std::string const cycle = xmlFindTextContent(li_node, XMLAttribute{ "class", "cycle" });
+  if (cycle.empty())
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Can't find a node with class=\"cycle\"" });
 
-        std::string const cycle = xmlFindTextContent(li_node, XMLAttribute {"class", "cycle"});
-        if (cycle.empty())
-            BOOST_THROW_EXCEPTION(ProtocolError {"Can't find a node with class=\"cycle\""});
-
-        return RAPIDExecutionInfo {
-            makeRAPIDExecutionState(ctrlexecstate),
-            makeRAPIDRunMode(cycle)
-        };
-    }
-
-
-    void startRAPIDExecution(RWSClient& client)
-    {
-        std::string const uri = Resources::RW_RAPID_EXECUTION + "?" + Queries::ACTION_START;
-        std::string const content = "regain=continue&execmode=continue&cycle=forever&condition=none&stopatbp=disabled&alltaskbytsp=false";
-        client.httpPost(uri, content);
-    }
-
-
-    void stopRAPIDExecution(RWSClient& client, StopMode stopmode, UseTsp usetsp)
-    {
-        std::stringstream content;
-        content << "stopmode=" << stopmode << "&usetsp=" << usetsp;
-        client.httpPost("/rw/rapid/execution?action=stop", content.str());
-    }
-
-
-    void resetRAPIDProgramPointer(RWSClient& client)
-    {
-        client.httpPost(Resources::RW_RAPID_EXECUTION + "?" + Queries::ACTION_RESETPP);
-    }
-
-
-    void getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource, RAPIDSymbolDataAbstract& data)
-    {
-        RWSResult const temp_result = getRAPIDSymbolProperties(client, resource);
-        std::string const data_type = xmlFindTextContent(temp_result, XMLAttributes::CLASS_DATTYP);
-
-        if (data.getType() == data_type)
-            data.parseString(getRAPIDSymbolData(client, resource));
-        else
-            BOOST_THROW_EXCEPTION(std::invalid_argument {"Argument type does not match the RAPID variable type"});
-    }
-
-
-    void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const RAPIDSymbolDataAbstract& data)
-    {
-        setRAPIDSymbolData(client, resource, data.constructString());
-    }
-
-
-    std::string getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource)
-    {
-        std::string const uri = generateRAPIDDataPath(resource);
-        RWSResult xml_content = parseXml(client.httpGet(uri).content());
-        std::string value = xmlFindTextContent(xml_content, XMLAttributes::CLASS_VALUE);
-
-        if (value.empty())
-            BOOST_THROW_EXCEPTION(std::logic_error {"RAPID value string was empty"});
-
-        return value;
-    }
-
-
-    void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const std::string& data)
-    {
-        std::string uri = generateRAPIDDataPath(resource) + "?" + Queries::ACTION_SET;
-        std::string content = Identifiers::VALUE + "=" + data;
-
-        client.httpPost(uri, content);
-    }
-
-
-    static RWSResult getRAPIDSymbolProperties(RWSClient& client, RAPIDResource const& resource)
-    {
-        std::string const uri = generateRAPIDPropertiesPath(resource);
-        return parseXml(client.httpGet(uri).content());
-    }
-
-
-    static std::string generateRAPIDDataPath(const RAPIDResource& resource)
-    {
-        return "/rw/rapid/symbol/data/RAPID/" + resource.task + "/" + resource.module + "/" + resource.name;
-    }
-
-
-    static std::string generateRAPIDPropertiesPath(const RAPIDResource& resource)
-    {
-        return "/rw/rapid/symbol/properties/RAPID/" + resource.task + "/" + resource.module + "/"+ resource.name;
-    }
-
-
-    std::vector<RAPIDModuleInfo> getRAPIDModulesInfo(RWSClient& client, const std::string& task)
-    {
-        std::vector<RAPIDModuleInfo> result;
-
-        std::string const uri = Resources::RW_RAPID_MODULES + "?" + Queries::TASK + task;
-        RWSResult const rws_result = parseXml(client.httpGet(uri).content());
-        std::vector<Poco::XML::Node*> node_list = xmlFindNodes(rws_result,
-                                                                XMLAttributes::CLASS_RAP_MODULE_INFO_LI);
-
-        for (size_t i = 0; i < node_list.size(); ++i)
-        {
-            std::string name = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_NAME);
-            std::string type = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_TYPE);
-
-            result.push_back(RAPIDModuleInfo(name, type));
-        }
-
-        return result;
-    }
-
-    std::vector<RAPIDTaskInfo> getRAPIDTasks(RWSClient& client)
-    {
-        std::vector<RAPIDTaskInfo> result;
-
-        RWSResult const rws_result = parseXml(client.httpGet(Resources::RW_RAPID_TASKS).content());
-        std::vector<Poco::XML::Node*> node_list = xmlFindNodes(rws_result, XMLAttributes::CLASS_RAP_TASK_LI);
-
-        for (size_t i = 0; i < node_list.size(); ++i)
-        {
-            std::string name = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_NAME);
-            bool is_motion_task = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_MOTIONTASK) == SystemConstants::RAPID::RAPID_TRUE;
-            bool is_active = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_ACTIVE) == "On";
-            std::string temp = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_EXCSTATE);
-
-            // Assume task state is unknown, update based on contents of 'temp'.
-            RAPIDTaskExecutionState execution_state = RAPIDTaskExecutionState::UNKNOWN;
-
-            if(temp == "read")
-            {
-                execution_state = RAPIDTaskExecutionState::READY;
-            }
-            else if(temp == "stop")
-            {
-                execution_state = RAPIDTaskExecutionState::STOPPED;
-            }
-            else if(temp == "star")
-            {
-                execution_state = RAPIDTaskExecutionState::STARTED;
-            }
-            else if(temp == "unin")
-            {
-                execution_state = RAPIDTaskExecutionState::UNINITIALIZED;
-            }
-
-            result.push_back(RAPIDTaskInfo(name, is_motion_task, is_active, execution_state));
-        }
-
-        return result;
-    }
-
-
-    void loadModuleIntoTask(RWSClient& client, const std::string& task, const FileResource& resource, const bool replace)
-    {
-        std::string uri = generateRAPIDTasksPath(task) + "?" + Queries::ACTION_LOAD_MODULE;
-
-        // Path to file should be a direct path, i.e. without "/fileservice/"
-        std::string content =
-            Identifiers::MODULEPATH + "=" + resource.directory + "/" + resource.filename +
-            "&replace=" + ((replace) ? "true" : "false");
-
-        client.httpPost(uri, content);
-    }
-
-
-    void unloadModuleFromTask(RWSClient& client, const std::string& task, const FileResource& resource)
-    {
-        std::string uri = generateRAPIDTasksPath(task) + "?" + Queries::ACTION_UNLOAD_MODULE;
-        std::string content = Identifiers::MODULE + "=" + resource.filename;
-
-        client.httpPost(uri, content);
-    }
-
-
-    static std::string generateRAPIDTasksPath(const std::string& task)
-    {
-        return Resources::RW_RAPID_TASKS + "/" + task;
-    }
+  return RAPIDExecutionInfo{ makeRAPIDExecutionState(ctrlexecstate), makeRAPIDRunMode(cycle) };
 }
+
+void startRAPIDExecution(RWSClient& client)
+{
+  std::string const uri = Resources::RW_RAPID_EXECUTION + "?" + Queries::ACTION_START;
+  std::string const content =
+      "regain=continue&execmode=continue&cycle=forever&condition=none&stopatbp=disabled&alltaskbytsp=false";
+  client.httpPost(uri, content);
+}
+
+void stopRAPIDExecution(RWSClient& client, StopMode stopmode, UseTsp usetsp)
+{
+  std::stringstream content;
+  content << "stopmode=" << stopmode << "&usetsp=" << usetsp;
+  client.httpPost("/rw/rapid/execution?action=stop", content.str());
+}
+
+void resetRAPIDProgramPointer(RWSClient& client)
+{
+  client.httpPost(Resources::RW_RAPID_EXECUTION + "?" + Queries::ACTION_RESETPP);
+}
+
+void getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource, RAPIDSymbolDataAbstract& data)
+{
+  RWSResult const temp_result = getRAPIDSymbolProperties(client, resource);
+  std::string const data_type = xmlFindTextContent(temp_result, XMLAttributes::CLASS_DATTYP);
+
+  if (data.getType() == data_type)
+    data.parseString(getRAPIDSymbolData(client, resource));
+  else
+    BOOST_THROW_EXCEPTION(std::invalid_argument{ "Argument type does not match the RAPID variable type" });
+}
+
+void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const RAPIDSymbolDataAbstract& data)
+{
+  setRAPIDSymbolData(client, resource, data.constructString());
+}
+
+std::string getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource)
+{
+  std::string const uri = generateRAPIDDataPath(resource);
+  RWSResult xml_content = parseXml(client.httpGet(uri).content());
+  std::string value = xmlFindTextContent(xml_content, XMLAttributes::CLASS_VALUE);
+
+  if (value.empty())
+    BOOST_THROW_EXCEPTION(std::logic_error{ "RAPID value string was empty" });
+
+  return value;
+}
+
+void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const std::string& data)
+{
+  std::string uri = generateRAPIDDataPath(resource) + "?" + Queries::ACTION_SET;
+  std::string content = Identifiers::VALUE + "=" + data;
+
+  client.httpPost(uri, content);
+}
+
+static RWSResult getRAPIDSymbolProperties(RWSClient& client, RAPIDResource const& resource)
+{
+  std::string const uri = generateRAPIDPropertiesPath(resource);
+  return parseXml(client.httpGet(uri).content());
+}
+
+static std::string generateRAPIDDataPath(const RAPIDResource& resource)
+{
+  return "/rw/rapid/symbol/data/RAPID/" + resource.task + "/" + resource.module + "/" + resource.name;
+}
+
+static std::string generateRAPIDPropertiesPath(const RAPIDResource& resource)
+{
+  return "/rw/rapid/symbol/properties/RAPID/" + resource.task + "/" + resource.module + "/" + resource.name;
+}
+
+std::vector<RAPIDModuleInfo> getRAPIDModulesInfo(RWSClient& client, const std::string& task)
+{
+  std::vector<RAPIDModuleInfo> result;
+
+  std::string const uri = Resources::RW_RAPID_MODULES + "?" + Queries::TASK + task;
+  RWSResult const rws_result = parseXml(client.httpGet(uri).content());
+  std::vector<Poco::XML::Node*> node_list = xmlFindNodes(rws_result, XMLAttributes::CLASS_RAP_MODULE_INFO_LI);
+
+  for (size_t i = 0; i < node_list.size(); ++i)
+  {
+    std::string name = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_NAME);
+    std::string type = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_TYPE);
+
+    result.push_back(RAPIDModuleInfo(name, type));
+  }
+
+  return result;
+}
+
+std::vector<RAPIDTaskInfo> getRAPIDTasks(RWSClient& client)
+{
+  std::vector<RAPIDTaskInfo> result;
+
+  RWSResult const rws_result = parseXml(client.httpGet(Resources::RW_RAPID_TASKS).content());
+  std::vector<Poco::XML::Node*> node_list = xmlFindNodes(rws_result, XMLAttributes::CLASS_RAP_TASK_LI);
+
+  for (size_t i = 0; i < node_list.size(); ++i)
+  {
+    std::string name = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_NAME);
+    bool is_motion_task =
+        xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_MOTIONTASK) == SystemConstants::RAPID::RAPID_TRUE;
+    bool is_active = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_ACTIVE) == "On";
+    std::string temp = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_EXCSTATE);
+
+    // Assume task state is unknown, update based on contents of 'temp'.
+    RAPIDTaskExecutionState execution_state = RAPIDTaskExecutionState::UNKNOWN;
+
+    if (temp == "read")
+    {
+      execution_state = RAPIDTaskExecutionState::READY;
+    }
+    else if (temp == "stop")
+    {
+      execution_state = RAPIDTaskExecutionState::STOPPED;
+    }
+    else if (temp == "star")
+    {
+      execution_state = RAPIDTaskExecutionState::STARTED;
+    }
+    else if (temp == "unin")
+    {
+      execution_state = RAPIDTaskExecutionState::UNINITIALIZED;
+    }
+
+    result.push_back(RAPIDTaskInfo(name, is_motion_task, is_active, execution_state));
+  }
+
+  return result;
+}
+
+void loadModuleIntoTask(RWSClient& client, const std::string& task, const FileResource& resource, const bool replace)
+{
+  std::string uri = generateRAPIDTasksPath(task) + "?" + Queries::ACTION_LOAD_MODULE;
+
+  // Path to file should be a direct path, i.e. without "/fileservice/"
+  std::string content = Identifiers::MODULEPATH + "=" + resource.directory + "/" + resource.filename +
+                        "&replace=" + ((replace) ? "true" : "false");
+
+  client.httpPost(uri, content);
+}
+
+void unloadModuleFromTask(RWSClient& client, const std::string& task, const FileResource& resource)
+{
+  std::string uri = generateRAPIDTasksPath(task) + "?" + Queries::ACTION_UNLOAD_MODULE;
+  std::string content = Identifiers::MODULE + "=" + resource.filename;
+
+  client.httpPost(uri, content);
+}
+
+static std::string generateRAPIDTasksPath(const std::string& task)
+{
+  return Resources::RW_RAPID_TASKS + "/" + task;
+}
+}  // namespace abb::rws::v1_0::rw::rapid

--- a/src/v1_0/rws.cpp
+++ b/src/v1_0/rws.cpp
@@ -5,118 +5,116 @@
 #include <stdexcept>
 #include <iostream>
 
-
-namespace abb :: rws :: v1_0
+namespace abb ::rws ::v1_0
 {
-  const std::string Identifiers::ACTIVE                         = "active";
-  const std::string Identifiers::ARM                            = "arm";
-  const std::string Identifiers::CFG_DT_INSTANCE_LI             = "cfg-dt-instance-li";
-  const std::string Identifiers::CFG_IA_T_LI                    = "cfg-ia-t-li";
-  const std::string Identifiers::CTRL_TYPE                      = "ctrl-type";
-  const std::string Identifiers::CTRLEXECSTATE                  = "ctrlexecstate";
-  const std::string Identifiers::CTRLSTATE                      = "ctrlstate";
-  const std::string Identifiers::DATTYP                         = "dattyp";
-  const std::string Identifiers::EXCSTATE                       = "excstate";
-  const std::string Identifiers::IOS_SIGNAL                     = "ios-signal";
-  const std::string Identifiers::HOME_DIRECTORY                 = "$home";
-  const std::string Identifiers::LVALUE                         = "lvalue";
-  const std::string Identifiers::MECHANICAL_UNIT                = "mechanical_unit";
-  const std::string Identifiers::MECHANICAL_UNIT_GROUP          = "mechanical_unit_group";
-  const std::string Identifiers::MOC                            = "moc";
-  const std::string Identifiers::MODULE                         = "module";
-  const std::string Identifiers::MODULEPATH                     = "modulepath";
-  const std::string Identifiers::MOTIONTASK                     = "motiontask";
-  const std::string Identifiers::NAME                           = "name";
-  const std::string Identifiers::OPMODE                         = "opmode";
-  const std::string Identifiers::PRESENT_OPTIONS                = "present_options";
-  const std::string Identifiers::RAP_MODULE_INFO_LI             = "rap-module-info-li";
-  const std::string Identifiers::RAP_TASK_LI                    = "rap-task-li";
-  const std::string Identifiers::ROBOT                          = "robot";
-  const std::string Identifiers::RW_VERSION_NAME                = "rwversionname";
-  const std::string Identifiers::SINGLE                         = "single";
-  const std::string Identifiers::STATE                          = "state";
-  const std::string Identifiers::SYS                            = "sys";
-  const std::string Identifiers::SYS_OPTION_LI                  = "sys-option-li";
-  const std::string Identifiers::SYS_SYSTEM_LI                  = "sys-system-li";
-  const std::string Identifiers::TITLE                          = "title";
-  const std::string Identifiers::TYPE                           = "type";
-  const std::string Identifiers::VALUE                          = "value";
-  const std::string Identifiers::CLASS                          = "class";
-  const std::string Identifiers::OPTION                         = "option";
-  const std::string Queries::ACTION_LOAD_MODULE                 = "action=loadmod";
-  const std::string Queries::ACTION_RELEASE                     = "action=release";
-  const std::string Queries::ACTION_REQUEST                     = "action=request";
-  const std::string Queries::ACTION_RESETPP                     = "action=resetpp";
-  const std::string Queries::ACTION_SET                         = "action=set";
-  const std::string Queries::ACTION_SETCTRLSTATE                = "action=setctrlstate";
-  const std::string Queries::ACTION_SET_LOCALE                  = "action=set-locale";
-  const std::string Queries::ACTION_START                       = "action=start";
-  const std::string Queries::ACTION_STOP                        = "action=stop";
-  const std::string Queries::ACTION_UNLOAD_MODULE               = "action=unloadmod";
-  const std::string Queries::TASK                               = "task=";
-  const std::string Services::CTRL                              = "/ctrl";
-  const std::string Services::FILESERVICE                       = "/fileservice";
-  const std::string Services::RW                                = "/rw";
-  const std::string Services::SUBSCRIPTION                      = "/subscription";
-  const std::string Services::USERS                             = "/users";
-  const std::string Resources::INSTANCES                        = "/instances";
-  const std::string Resources::JOINTTARGET                      = "/jointtarget";
-  const std::string Resources::LOGOUT                           = "/logout";
-  const std::string Resources::ROBTARGET                        = "/robtarget";
-  const std::string Resources::RW_CFG                           = Services::RW + "/cfg";
-  const std::string Resources::RW_IOSYSTEM_SIGNALS              = Services::RW + "/iosystem/signals";
-  const std::string Resources::RW_MASTERSHIP                    = Services::RW + "/mastership";
-  const std::string Resources::RW_MOTIONSYSTEM_MECHUNITS        = Services::RW + "/motionsystem/mechunits";
-  const std::string Resources::RW_PANEL_CTRLSTATE               = Services::RW + "/panel/ctrlstate";
-  const std::string Resources::RW_PANEL_OPMODE                  = Services::RW + "/panel/opmode";
-  const std::string Resources::RW_RAPID_EXECUTION               = Services::RW + "/rapid/execution";
-  const std::string Resources::RW_RAPID_MODULES                 = Services::RW + "/rapid/modules";
-  const std::string Resources::RW_RAPID_SYMBOL_DATA_RAPID       = Services::RW + "/rapid/symbol/data/RAPID";
-  const std::string Resources::RW_RAPID_SYMBOL_PROPERTIES_RAPID = Services::RW + "/rapid/symbol/properties/RAPID";
-  const std::string Resources::RW_RAPID_TASKS                   = Services::RW + "/rapid/tasks";
-  const std::string Resources::RW_SYSTEM                        = Services::RW + "/system";
+const std::string Identifiers::ACTIVE = "active";
+const std::string Identifiers::ARM = "arm";
+const std::string Identifiers::CFG_DT_INSTANCE_LI = "cfg-dt-instance-li";
+const std::string Identifiers::CFG_IA_T_LI = "cfg-ia-t-li";
+const std::string Identifiers::CTRL_TYPE = "ctrl-type";
+const std::string Identifiers::CTRLEXECSTATE = "ctrlexecstate";
+const std::string Identifiers::CTRLSTATE = "ctrlstate";
+const std::string Identifiers::DATTYP = "dattyp";
+const std::string Identifiers::EXCSTATE = "excstate";
+const std::string Identifiers::IOS_SIGNAL = "ios-signal";
+const std::string Identifiers::HOME_DIRECTORY = "$home";
+const std::string Identifiers::LVALUE = "lvalue";
+const std::string Identifiers::MECHANICAL_UNIT = "mechanical_unit";
+const std::string Identifiers::MECHANICAL_UNIT_GROUP = "mechanical_unit_group";
+const std::string Identifiers::MOC = "moc";
+const std::string Identifiers::MODULE = "module";
+const std::string Identifiers::MODULEPATH = "modulepath";
+const std::string Identifiers::MOTIONTASK = "motiontask";
+const std::string Identifiers::NAME = "name";
+const std::string Identifiers::OPMODE = "opmode";
+const std::string Identifiers::PRESENT_OPTIONS = "present_options";
+const std::string Identifiers::RAP_MODULE_INFO_LI = "rap-module-info-li";
+const std::string Identifiers::RAP_TASK_LI = "rap-task-li";
+const std::string Identifiers::ROBOT = "robot";
+const std::string Identifiers::RW_VERSION_NAME = "rwversionname";
+const std::string Identifiers::SINGLE = "single";
+const std::string Identifiers::STATE = "state";
+const std::string Identifiers::SYS = "sys";
+const std::string Identifiers::SYS_OPTION_LI = "sys-option-li";
+const std::string Identifiers::SYS_SYSTEM_LI = "sys-system-li";
+const std::string Identifiers::TITLE = "title";
+const std::string Identifiers::TYPE = "type";
+const std::string Identifiers::VALUE = "value";
+const std::string Identifiers::CLASS = "class";
+const std::string Identifiers::OPTION = "option";
+const std::string Queries::ACTION_LOAD_MODULE = "action=loadmod";
+const std::string Queries::ACTION_RELEASE = "action=release";
+const std::string Queries::ACTION_REQUEST = "action=request";
+const std::string Queries::ACTION_RESETPP = "action=resetpp";
+const std::string Queries::ACTION_SET = "action=set";
+const std::string Queries::ACTION_SETCTRLSTATE = "action=setctrlstate";
+const std::string Queries::ACTION_SET_LOCALE = "action=set-locale";
+const std::string Queries::ACTION_START = "action=start";
+const std::string Queries::ACTION_STOP = "action=stop";
+const std::string Queries::ACTION_UNLOAD_MODULE = "action=unloadmod";
+const std::string Queries::TASK = "task=";
+const std::string Services::CTRL = "/ctrl";
+const std::string Services::FILESERVICE = "/fileservice";
+const std::string Services::RW = "/rw";
+const std::string Services::SUBSCRIPTION = "/subscription";
+const std::string Services::USERS = "/users";
+const std::string Resources::INSTANCES = "/instances";
+const std::string Resources::JOINTTARGET = "/jointtarget";
+const std::string Resources::LOGOUT = "/logout";
+const std::string Resources::ROBTARGET = "/robtarget";
+const std::string Resources::RW_CFG = Services::RW + "/cfg";
+const std::string Resources::RW_IOSYSTEM_SIGNALS = Services::RW + "/iosystem/signals";
+const std::string Resources::RW_MASTERSHIP = Services::RW + "/mastership";
+const std::string Resources::RW_MOTIONSYSTEM_MECHUNITS = Services::RW + "/motionsystem/mechunits";
+const std::string Resources::RW_PANEL_CTRLSTATE = Services::RW + "/panel/ctrlstate";
+const std::string Resources::RW_PANEL_OPMODE = Services::RW + "/panel/opmode";
+const std::string Resources::RW_RAPID_EXECUTION = Services::RW + "/rapid/execution";
+const std::string Resources::RW_RAPID_MODULES = Services::RW + "/rapid/modules";
+const std::string Resources::RW_RAPID_SYMBOL_DATA_RAPID = Services::RW + "/rapid/symbol/data/RAPID";
+const std::string Resources::RW_RAPID_SYMBOL_PROPERTIES_RAPID = Services::RW + "/rapid/symbol/properties/RAPID";
+const std::string Resources::RW_RAPID_TASKS = Services::RW + "/rapid/tasks";
+const std::string Resources::RW_SYSTEM = Services::RW + "/system";
 
-  const XMLAttribute XMLAttributes::CLASS_ACTIVE(Identifiers::CLASS            , Identifiers::ACTIVE);
-  const XMLAttribute XMLAttributes::CLASS_CFG_DT_INSTANCE_LI(Identifiers::CLASS, Identifiers::CFG_DT_INSTANCE_LI);
-  const XMLAttribute XMLAttributes::CLASS_CFG_IA_T_LI(Identifiers::CLASS       , Identifiers::CFG_IA_T_LI);
-  const XMLAttribute XMLAttributes::CLASS_CTRL_TYPE(Identifiers::CLASS         , Identifiers::CTRL_TYPE);
-  const XMLAttribute XMLAttributes::CLASS_CTRLEXECSTATE(Identifiers::CLASS     , Identifiers::CTRLEXECSTATE);
-  const XMLAttribute XMLAttributes::CLASS_CTRLSTATE(Identifiers::CLASS         , Identifiers::CTRLSTATE);
-  const XMLAttribute XMLAttributes::CLASS_DATTYP(Identifiers::CLASS            , Identifiers::DATTYP);
-  const XMLAttribute XMLAttributes::CLASS_EXCSTATE(Identifiers::CLASS          , Identifiers::EXCSTATE);
-  const XMLAttribute XMLAttributes::CLASS_IOS_SIGNAL(Identifiers::CLASS        , Identifiers::IOS_SIGNAL);
-  const XMLAttribute XMLAttributes::CLASS_LVALUE(Identifiers::CLASS            , Identifiers::LVALUE);
-  const XMLAttribute XMLAttributes::CLASS_MOTIONTASK(Identifiers::CLASS        , Identifiers::MOTIONTASK);
-  const XMLAttribute XMLAttributes::CLASS_NAME(Identifiers::CLASS              , Identifiers::NAME);
-  const XMLAttribute XMLAttributes::CLASS_OPMODE(Identifiers::CLASS            , Identifiers::OPMODE);
-  const XMLAttribute XMLAttributes::CLASS_RAP_MODULE_INFO_LI(Identifiers::CLASS, Identifiers::RAP_MODULE_INFO_LI);
-  const XMLAttribute XMLAttributes::CLASS_RAP_TASK_LI(Identifiers::CLASS       , Identifiers::RAP_TASK_LI);
-  const XMLAttribute XMLAttributes::CLASS_RW_VERSION_NAME(Identifiers::CLASS   , Identifiers::RW_VERSION_NAME);
-  const XMLAttribute XMLAttributes::CLASS_STATE(Identifiers::CLASS             , Identifiers::STATE);
-  const XMLAttribute XMLAttributes::CLASS_SYS_OPTION_LI(Identifiers::CLASS     , Identifiers::SYS_OPTION_LI);
-  const XMLAttribute XMLAttributes::CLASS_SYS_SYSTEM_LI(Identifiers::CLASS     , Identifiers::SYS_SYSTEM_LI);
-  const XMLAttribute XMLAttributes::CLASS_TYPE(Identifiers::CLASS              , Identifiers::TYPE);
-  const XMLAttribute XMLAttributes::CLASS_VALUE(Identifiers::CLASS             , Identifiers::VALUE);
-  const XMLAttribute XMLAttributes::CLASS_OPTION(Identifiers::CLASS            , Identifiers::OPTION);
+const XMLAttribute XMLAttributes::CLASS_ACTIVE(Identifiers::CLASS, Identifiers::ACTIVE);
+const XMLAttribute XMLAttributes::CLASS_CFG_DT_INSTANCE_LI(Identifiers::CLASS, Identifiers::CFG_DT_INSTANCE_LI);
+const XMLAttribute XMLAttributes::CLASS_CFG_IA_T_LI(Identifiers::CLASS, Identifiers::CFG_IA_T_LI);
+const XMLAttribute XMLAttributes::CLASS_CTRL_TYPE(Identifiers::CLASS, Identifiers::CTRL_TYPE);
+const XMLAttribute XMLAttributes::CLASS_CTRLEXECSTATE(Identifiers::CLASS, Identifiers::CTRLEXECSTATE);
+const XMLAttribute XMLAttributes::CLASS_CTRLSTATE(Identifiers::CLASS, Identifiers::CTRLSTATE);
+const XMLAttribute XMLAttributes::CLASS_DATTYP(Identifiers::CLASS, Identifiers::DATTYP);
+const XMLAttribute XMLAttributes::CLASS_EXCSTATE(Identifiers::CLASS, Identifiers::EXCSTATE);
+const XMLAttribute XMLAttributes::CLASS_IOS_SIGNAL(Identifiers::CLASS, Identifiers::IOS_SIGNAL);
+const XMLAttribute XMLAttributes::CLASS_LVALUE(Identifiers::CLASS, Identifiers::LVALUE);
+const XMLAttribute XMLAttributes::CLASS_MOTIONTASK(Identifiers::CLASS, Identifiers::MOTIONTASK);
+const XMLAttribute XMLAttributes::CLASS_NAME(Identifiers::CLASS, Identifiers::NAME);
+const XMLAttribute XMLAttributes::CLASS_OPMODE(Identifiers::CLASS, Identifiers::OPMODE);
+const XMLAttribute XMLAttributes::CLASS_RAP_MODULE_INFO_LI(Identifiers::CLASS, Identifiers::RAP_MODULE_INFO_LI);
+const XMLAttribute XMLAttributes::CLASS_RAP_TASK_LI(Identifiers::CLASS, Identifiers::RAP_TASK_LI);
+const XMLAttribute XMLAttributes::CLASS_RW_VERSION_NAME(Identifiers::CLASS, Identifiers::RW_VERSION_NAME);
+const XMLAttribute XMLAttributes::CLASS_STATE(Identifiers::CLASS, Identifiers::STATE);
+const XMLAttribute XMLAttributes::CLASS_SYS_OPTION_LI(Identifiers::CLASS, Identifiers::SYS_OPTION_LI);
+const XMLAttribute XMLAttributes::CLASS_SYS_SYSTEM_LI(Identifiers::CLASS, Identifiers::SYS_SYSTEM_LI);
+const XMLAttribute XMLAttributes::CLASS_TYPE(Identifiers::CLASS, Identifiers::TYPE);
+const XMLAttribute XMLAttributes::CLASS_VALUE(Identifiers::CLASS, Identifiers::VALUE);
+const XMLAttribute XMLAttributes::CLASS_OPTION(Identifiers::CLASS, Identifiers::OPTION);
 
-
-  std::ostream& operator<<(std::ostream& os, MastershipDomain domain)
+std::ostream& operator<<(std::ostream& os, MastershipDomain domain)
+{
+  switch (domain)
   {
-    switch (domain)
-    {
-      case MastershipDomain::cfg:
-        os << "cfg";
-        break;
-      case MastershipDomain::motion:
-        os << "motion";
-        break;
-      case MastershipDomain::rapid:
-        os << "rapid";
-        break;
-      default:
-        BOOST_THROW_EXCEPTION(std::logic_error {"Invalid v1_0::MastershipDomain value"});
-    }
-
-    return os;
+    case MastershipDomain::cfg:
+      os << "cfg";
+      break;
+    case MastershipDomain::motion:
+      os << "motion";
+      break;
+    case MastershipDomain::rapid:
+      os << "rapid";
+      break;
+    default:
+      BOOST_THROW_EXCEPTION(std::logic_error{ "Invalid v1_0::MastershipDomain value" });
   }
+
+  return os;
 }
+}  // namespace abb::rws::v1_0

--- a/src/v1_0/rws_client.cpp
+++ b/src/v1_0/rws_client.cpp
@@ -46,11 +46,9 @@
 
 #include <iostream>
 
-
-namespace abb :: rws :: v1_0
+namespace abb ::rws ::v1_0
 {
 using namespace Poco::Net;
-
 
 /***********************************************************************************************************************
  * Class definitions: RWSClient
@@ -61,20 +59,16 @@ using namespace Poco::Net;
  */
 
 RWSClient::RWSClient(ConnectionOptions const& connection_options)
-: connectionOptions_ {connection_options}
-, session_ {connectionOptions_.ip_address, connectionOptions_.port}
-, http_client_ {session_, connectionOptions_.username, connectionOptions_.password}
+  : connectionOptions_{ connection_options }
+  , session_{ connectionOptions_.ip_address, connectionOptions_.port }
+  , http_client_{ session_, connectionOptions_.username, connectionOptions_.password }
 {
-  session_.setTimeout(
-    connectionOptions_.connection_timeout.count(),
-    connectionOptions_.send_timeout.count(),
-    connectionOptions_.receive_timeout.count()
-  );
+  session_.setTimeout(connectionOptions_.connection_timeout.count(), connectionOptions_.send_timeout.count(),
+                      connectionOptions_.receive_timeout.count());
 
   // Make a request to the server to check connection and initiate authentification.
   getRobotWareSystem();
 }
-
 
 RWSClient::~RWSClient()
 {
@@ -89,7 +83,6 @@ RWSClient::~RWSClient()
   }
 }
 
-
 RWSResult RWSClient::getContollerService()
 {
   std::string uri = Services::CTRL;
@@ -101,7 +94,6 @@ RWSResult RWSClient::getConfigurationInstances(const std::string& topic, const s
   std::string uri = generateConfigurationPath(topic, type) + Resources::INSTANCES;
   return parseContent(httpGet(uri));
 }
-
 
 RWSResult RWSClient::getMechanicalUnitStaticInfo(const std::string& mechunit)
 {
@@ -121,10 +113,8 @@ RWSResult RWSClient::getMechanicalUnitJointTarget(const std::string& mechunit)
   return parseContent(httpGet(uri));
 }
 
-RWSResult RWSClient::getMechanicalUnitRobTarget(const std::string& mechunit,
-                                                           Coordinate coordinate,
-                                                           const std::string& tool,
-                                                           const std::string& wobj)
+RWSResult RWSClient::getMechanicalUnitRobTarget(const std::string& mechunit, Coordinate coordinate,
+                                                const std::string& tool, const std::string& wobj)
 {
   std::string uri = generateMechanicalUnitPath(mechunit) + Resources::ROBTARGET;
 
@@ -143,20 +133,20 @@ RWSResult RWSClient::getMechanicalUnitRobTarget(const std::string& mechunit,
   {
     case Coordinate::BASE:
       uri += coordinate_arg + SystemConstants::General::COORDINATE_BASE + args;
-    break;
+      break;
     case Coordinate::WORLD:
       uri += coordinate_arg + SystemConstants::General::COORDINATE_WORLD + args;
-    break;
+      break;
     case Coordinate::TOOL:
       uri += coordinate_arg + SystemConstants::General::COORDINATE_TOOL + args;
-    break;
+      break;
     case Coordinate::WOBJ:
       uri += coordinate_arg + SystemConstants::General::COORDINATE_WOBJ + args;
-    break;
+      break;
     default:
       // If the "ACTIVE" enumeration is passed in (or any other non-identified value),
       // do not add any arguments to this command
-    break;
+      break;
   }
 
   return parseContent(httpGet(uri));
@@ -189,35 +179,27 @@ void RWSClient::deleteFile(const FileResource& resource)
   httpDelete(uri);
 }
 
-
 void RWSClient::logout()
 {
   std::string uri = Resources::LOGOUT;
   httpGet(uri);
 }
 
-
-void RWSClient::registerLocalUser(const std::string& username,
-                                                  const std::string& application,
-                                                  const std::string& location)
+void RWSClient::registerLocalUser(const std::string& username, const std::string& application,
+                                  const std::string& location)
 {
   std::string uri = Services::USERS;
-  std::string content = "username=" + username +
-             "&application=" + application +
-             "&location=" + location +
-             "&ulocale=" + SystemConstants::General::LOCAL;
+  std::string content = "username=" + username + "&application=" + application + "&location=" + location +
+                        "&ulocale=" + SystemConstants::General::LOCAL;
 
   httpPost(uri, content);
 }
 
-void RWSClient::registerRemoteUser(const std::string& username,
-                                                   const std::string& application,
-                                                   const std::string& location)
+void RWSClient::registerRemoteUser(const std::string& username, const std::string& application,
+                                   const std::string& location)
 {
   std::string uri = Services::USERS;
-  std::string content = "username=" + username +
-                        "&application=" + application +
-                        "&location=" + location +
+  std::string content = "username=" + username + "&application=" + application + "&location=" + location +
                         "&ulocale=" + SystemConstants::General::REMOTE;
 
   httpPost(uri, content);
@@ -232,12 +214,10 @@ RWSResult RWSClient::parseContent(const POCOResult& poco_result)
   return parser_.parseString(poco_result.content());
 }
 
-
 std::string RWSClient::generateConfigurationPath(const std::string& topic, const std::string& type)
 {
   return Resources::RW_CFG + "/" + topic + "/" + type;
 }
-
 
 std::string RWSClient::generateMechanicalUnitPath(const std::string& mechunit)
 {
@@ -249,75 +229,58 @@ std::string RWSClient::generateFilePath(const FileResource& resource)
   return Services::FILESERVICE + "/" + resource.directory + "/" + resource.filename;
 }
 
-
 POCOResult RWSClient::httpGet(const std::string& uri)
 {
   POCOResult const result = http_client_.httpGet(uri);
 
   if (result.httpStatus() != HTTPResponse::HTTP_OK)
-    BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
-      << HttpMethodErrorInfo {"GET"}
-      << UriErrorInfo {uri}
-      << HttpStatusErrorInfo {result.httpStatus()}
-      << HttpResponseContentErrorInfo {result.content()}
-      << HttpReasonErrorInfo {result.reason()}
-    );
+    BOOST_THROW_EXCEPTION(
+        ProtocolError{ "HTTP response status not accepted" }
+        << HttpMethodErrorInfo{ "GET" } << UriErrorInfo{ uri } << HttpStatusErrorInfo{ result.httpStatus() }
+        << HttpResponseContentErrorInfo{ result.content() } << HttpReasonErrorInfo{ result.reason() });
 
   return result;
 }
 
-
 POCOResult RWSClient::httpPost(const std::string& uri, const std::string& content,
-  std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status)
+                               std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status)
 {
   POCOResult const result = http_client_.httpPost(uri, content);
 
   if (accepted_status.find(result.httpStatus()) == accepted_status.end())
-    BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
-      << HttpMethodErrorInfo {"POST"}
-      << UriErrorInfo {uri}
-      << HttpStatusErrorInfo {result.httpStatus()}
-      << HttpResponseContentErrorInfo {result.content()}
-      << HttpRequestContentErrorInfo {content}
-      << HttpReasonErrorInfo {result.reason()}
-    );
+    BOOST_THROW_EXCEPTION(ProtocolError{ "HTTP response status not accepted" }
+                          << HttpMethodErrorInfo{ "POST" } << UriErrorInfo{ uri }
+                          << HttpStatusErrorInfo{ result.httpStatus() }
+                          << HttpResponseContentErrorInfo{ result.content() } << HttpRequestContentErrorInfo{ content }
+                          << HttpReasonErrorInfo{ result.reason() });
 
   return result;
 }
-
 
 POCOResult RWSClient::httpPut(const std::string& uri, const std::string& content)
 {
   POCOResult const result = http_client_.httpPut(uri, content);
   if (result.httpStatus() != HTTPResponse::HTTP_OK && result.httpStatus() != HTTPResponse::HTTP_CREATED)
-    BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
-      << HttpMethodErrorInfo {"PUT"}
-      << UriErrorInfo {uri}
-      << HttpStatusErrorInfo {result.httpStatus()}
-      << HttpResponseContentErrorInfo {result.content()}
-      << HttpRequestContentErrorInfo {content}
-      << HttpReasonErrorInfo {result.reason()}
-    );
+    BOOST_THROW_EXCEPTION(ProtocolError{ "HTTP response status not accepted" }
+                          << HttpMethodErrorInfo{ "PUT" } << UriErrorInfo{ uri }
+                          << HttpStatusErrorInfo{ result.httpStatus() }
+                          << HttpResponseContentErrorInfo{ result.content() } << HttpRequestContentErrorInfo{ content }
+                          << HttpReasonErrorInfo{ result.reason() });
 
   return result;
 }
-
 
 POCOResult RWSClient::httpDelete(const std::string& uri)
 {
   POCOResult const result = http_client_.httpDelete(uri);
   if (result.httpStatus() != HTTPResponse::HTTP_OK && result.httpStatus() != HTTPResponse::HTTP_NO_CONTENT)
-    BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
-      << HttpMethodErrorInfo {"DELETE"}
-      << HttpStatusErrorInfo {result.httpStatus()}
-      << HttpResponseContentErrorInfo {result.content()}
-      << UriErrorInfo {uri}
-      << HttpReasonErrorInfo {result.reason()}
-    );
+    BOOST_THROW_EXCEPTION(ProtocolError{ "HTTP response status not accepted" }
+                          << HttpMethodErrorInfo{ "DELETE" } << HttpStatusErrorInfo{ result.httpStatus() }
+                          << HttpResponseContentErrorInfo{ result.content() } << UriErrorInfo{ uri }
+                          << HttpReasonErrorInfo{ result.reason() });
 
   return result;
 }
-
 
 std::string RWSClient::openSubscription(std::vector<std::pair<std::string, SubscriptionPriority>> const& resources)
 {
@@ -325,12 +288,8 @@ std::string RWSClient::openSubscription(std::vector<std::pair<std::string, Subsc
   std::stringstream subscription_content;
   for (std::size_t i = 0; i < resources.size(); ++i)
   {
-    subscription_content << "resources=" << i
-                          << "&"
-                          << i << "=" << resources[i].first
-                          << "&"
-                          << i << "-p=" << static_cast<int>(resources[i].second)
-                          << (i < resources.size() - 1 ? "&" : "");
+    subscription_content << "resources=" << i << "&" << i << "=" << resources[i].first << "&" << i
+                         << "-p=" << static_cast<int>(resources[i].second) << (i < resources.size() - 1 ? "&" : "");
   }
 
   // Make a subscription request.
@@ -338,22 +297,17 @@ std::string RWSClient::openSubscription(std::vector<std::pair<std::string, Subsc
 
   if (poco_result.httpStatus() != HTTPResponse::HTTP_CREATED)
     BOOST_THROW_EXCEPTION(
-      ProtocolError {"Unable to create Subscription"}
-      << HttpStatusErrorInfo {poco_result.httpStatus()}
-      << HttpReasonErrorInfo {poco_result.reason()}
-      << HttpMethodErrorInfo {HTTPRequest::HTTP_POST}
-      << HttpRequestContentErrorInfo {subscription_content.str()}
-      << HttpResponseContentErrorInfo {poco_result.content()}
-      << HttpResponseErrorInfo {poco_result}
-      << UriErrorInfo {Services::SUBSCRIPTION}
-    );
+        ProtocolError{ "Unable to create Subscription" }
+        << HttpStatusErrorInfo{ poco_result.httpStatus() } << HttpReasonErrorInfo{ poco_result.reason() }
+        << HttpMethodErrorInfo{ HTTPRequest::HTTP_POST } << HttpRequestContentErrorInfo{ subscription_content.str() }
+        << HttpResponseContentErrorInfo{ poco_result.content() } << HttpResponseErrorInfo{ poco_result }
+        << UriErrorInfo{ Services::SUBSCRIPTION });
 
   std::string subscription_group_id;
 
   // Find "Location" header attribute
-  auto const h = std::find_if(
-    poco_result.headerInfo().begin(), poco_result.headerInfo().end(),
-    [] (auto const& p) { return p.first == "Location"; });
+  auto const h = std::find_if(poco_result.headerInfo().begin(), poco_result.headerInfo().end(),
+                              [](auto const& p) { return p.first == "Location"; });
 
   if (h != poco_result.headerInfo().end())
   {
@@ -365,11 +319,10 @@ std::string RWSClient::openSubscription(std::vector<std::pair<std::string, Subsc
   }
 
   if (subscription_group_id.empty())
-    BOOST_THROW_EXCEPTION(ProtocolError {"Cannot get subscription group from HTTP response"});
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot get subscription group from HTTP response" });
 
   return subscription_group_id;
 }
-
 
 void RWSClient::closeSubscription(std::string const& subscription_group_id)
 {
@@ -378,13 +331,12 @@ void RWSClient::closeSubscription(std::string const& subscription_group_id)
   httpDelete(uri);
 }
 
-
 Poco::Net::WebSocket RWSClient::receiveSubscription(std::string const& subscription_group_id)
 {
-  return http_client_.webSocketConnect("/poll/" + subscription_group_id, "robapi2_subscription",
-    Poco::Net::HTTPClientSession {connectionOptions_.ip_address, connectionOptions_.port});
+  return http_client_.webSocketConnect(
+      "/poll/" + subscription_group_id, "robapi2_subscription",
+      Poco::Net::HTTPClientSession{ connectionOptions_.ip_address, connectionOptions_.port });
 }
-
 
 std::string RWSClient::getResourceURI(IOSignalResource const& io_signal) const
 {
@@ -395,7 +347,6 @@ std::string RWSClient::getResourceURI(IOSignalResource const& io_signal) const
   resource_uri += Identifiers::STATE;
   return resource_uri;
 }
-
 
 std::string RWSClient::getResourceURI(RAPIDResource const& resource) const
 {
@@ -411,35 +362,31 @@ std::string RWSClient::getResourceURI(RAPIDResource const& resource) const
   return resource_uri;
 }
 
-
 std::string RWSClient::getResourceURI(ControllerStateResource const&) const
 {
   return "/rw/panel/ctrlstate";
 }
-
 
 std::string RWSClient::getResourceURI(RAPIDExecutionStateResource const&) const
 {
   return "/rw/rapid/execution;ctrlexecstate";
 }
 
-
 std::string RWSClient::getResourceURI(OperationModeResource const&) const
 {
   return "/rw/panel/opmode";
 }
 
-
 void RWSClient::processEvent(Poco::AutoPtr<Poco::XML::Document> doc, SubscriptionCallback& callback) const
 {
   // IMPORTANT: don't use AutoPtr<XML::Node> here! Otherwise you will get memory corruption.
-  Poco::XML::Node const * li_node = doc->getNodeByPath("html/body/div/ul/li");
+  Poco::XML::Node const* li_node = doc->getNodeByPath("html/body/div/ul/li");
   if (!li_node)
-    BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: can't find XML path html/body/div/ul/li"});
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS event message: can't find XML path html/body/div/ul/li" });
 
-  auto const * a_node = li_node->getNodeByPath("a");
+  auto const* a_node = li_node->getNodeByPath("a");
   if (!a_node)
-    BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: can't find XML path html/body/div/ul/li/a"});
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS event message: can't find XML path html/body/div/ul/li/a" });
 
   std::string uri;
   uri = xmlNodeGetAttributeValue(a_node, "href");
@@ -452,31 +399,33 @@ void RWSClient::processEvent(Poco::AutoPtr<Poco::XML::Document> doc, Subscriptio
     std::string const prefix = "/rw/iosystem/signals/";
 
     if (uri.find(prefix) != 0)
-      BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: invalid resource URI"} << UriErrorInfo {uri});
+      BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS event message: invalid resource URI" }
+                            << UriErrorInfo{ uri });
 
     event.signal = uri.substr(prefix.length(), uri.find(";") - prefix.length());
-    event.value = xmlFindTextContent(li_node, XMLAttribute {"class", "lvalue"});
+    event.value = xmlFindTextContent(li_node, XMLAttribute{ "class", "lvalue" });
     callback.processEvent(event);
   }
   else if (class_attribute_value == "rap-ctrlexecstate-ev")
   {
     RAPIDExecutionStateEvent event;
-    event.state = rw::makeRAPIDExecutionState(xmlFindTextContent(li_node, XMLAttribute {"class", "ctrlexecstate"}));
+    event.state = rw::makeRAPIDExecutionState(xmlFindTextContent(li_node, XMLAttribute{ "class", "ctrlexecstate" }));
     callback.processEvent(event);
   }
   else if (class_attribute_value == "pnl-ctrlstate-ev")
   {
     ControllerStateEvent event;
-    event.state = rw::makeControllerState(xmlFindTextContent(li_node, XMLAttribute {"class", "ctrlstate"}));
+    event.state = rw::makeControllerState(xmlFindTextContent(li_node, XMLAttribute{ "class", "ctrlstate" }));
     callback.processEvent(event);
   }
   else if (class_attribute_value == "pnl-opmode-ev")
   {
     OperationModeEvent event;
-    event.mode = rw::makeOperationMode(xmlFindTextContent(li_node, XMLAttribute {"class", "opmode"}));
+    event.mode = rw::makeOperationMode(xmlFindTextContent(li_node, XMLAttribute{ "class", "opmode" }));
     callback.processEvent(event);
   }
   else
-    BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: unrecognized class " + class_attribute_value});
+    BOOST_THROW_EXCEPTION(
+        ProtocolError{ "Cannot parse RWS event message: unrecognized class " + class_attribute_value });
 }
-}
+}  // namespace abb::rws::v1_0

--- a/src/v1_0/rws_interface.cpp
+++ b/src/v1_0/rws_interface.cpp
@@ -46,30 +46,26 @@
 #include <iomanip>
 #include <stdexcept>
 
-
 namespace
 {
-static const char EXCEPTION_GET_CFG[]{"Failed to get configuration instances"};
-static const char EXCEPTION_PARSE_CFG[]{"Failed to parse configuration instances"};
-}
+static const char EXCEPTION_GET_CFG[]{ "Failed to get configuration instances" };
+static const char EXCEPTION_PARSE_CFG[]{ "Failed to parse configuration instances" };
+}  // namespace
 
-namespace abb :: rws :: v1_0
+namespace abb ::rws ::v1_0
 {
-
 typedef SystemConstants::ContollerStates ContollerStates;
 typedef SystemConstants::RAPID RAPID;
-
 
 /***********************************************************************************************************************
  * Class definitions: RWSInterface
  */
 
- /************************************************************
+/************************************************************
  * Primary methods
  */
 
-RWSInterface::RWSInterface(RWSClient& client)
-: rws_client_ {client}
+RWSInterface::RWSInterface(RWSClient& client) : rws_client_{ client }
 {
 }
 
@@ -92,31 +88,34 @@ std::vector<cfg::moc::Arm> RWSInterface::getCFGArms()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::Arm arm;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
       {
         arm.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(arm.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (arm.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "lower_joint_bound"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "lower_joint_bound"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> arm.lower_joint_bound;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "upper_joint_bound"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "upper_joint_bound"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> arm.upper_joint_bound;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
     }
 
@@ -135,41 +134,46 @@ std::vector<cfg::moc::Joint> RWSInterface::getCFGJoints()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::Joint joint;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
       {
         joint.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(joint.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (joint.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "logical_axis"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "logical_axis"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> joint.logical_axis;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "kinematic_axis_number"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "kinematic_axis_number"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> joint.kinematic_axis_number;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_arm"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_arm"))
       {
         joint.use_arm = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(joint.use_arm.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (joint.use_arm.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_transmission"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_transmission"))
       {
         joint.use_transmission = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(joint.use_transmission.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (joint.use_transmission.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
     }
 
@@ -188,31 +192,32 @@ std::vector<cfg::moc::MechanicalUnit> RWSInterface::getCFGMechanicalUnits()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::MechanicalUnit mechanical_unit;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
       {
         mechanical_unit.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(mechanical_unit.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (mechanical_unit.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_robot"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_robot"))
       {
         // Note: The 'use_robot' attribute can be empty, since not all units have a robot (i.e. skip validation).
         mechanical_unit.use_robot = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_0") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_1") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_2") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_3") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_4") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_5"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_0") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_1") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_2") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_3") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_4") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_5"))
       {
         // Note: The 'use_single_N' attribute can be empty, since not all units have singles (i.e. skip validation).
         mechanical_unit.use_singles.push_back(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
@@ -234,31 +239,32 @@ std::vector<cfg::sys::MechanicalUnitGroup> RWSInterface::getCFGMechanicalUnitGro
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::sys::MechanicalUnitGroup mechanical_unit_group;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "Name"))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "Name"))
       {
         mechanical_unit_group.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(mechanical_unit_group.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (mechanical_unit_group.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "Robot"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "Robot"))
       {
         // Note: The 'Robot' attribute can be empty, since not all groups have a robot (i.e. skip validation).
         mechanical_unit_group.robot = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_1") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_2") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_3") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_4") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_5") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_6"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_1") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_2") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_3") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_4") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_5") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_6"))
       {
         // Note: The 'MechanicalUnit_N' attribute can be empty, since not all groups have units (i.e. skip validation).
         mechanical_unit_group.mechanical_units.push_back(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
@@ -280,24 +286,26 @@ std::vector<cfg::sys::PresentOption> RWSInterface::getCFGPresentOptions()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::sys::PresentOption present_option;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "name"))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "name"))
       {
         present_option.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(present_option.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (present_option.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "desc"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "desc"))
       {
         present_option.description = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(present_option.description.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (present_option.description.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
     }
 
@@ -316,81 +324,90 @@ std::vector<cfg::moc::Robot> RWSInterface::getCFGRobots()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::Robot robot;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
       {
         robot.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(robot.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (robot.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_robot_type"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_robot_type"))
       {
         robot.use_robot_type = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(robot.use_robot_type.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (robot.use_robot_type.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_0") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_1") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_2") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_3") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_4") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_5"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_0") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_1") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_2") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_3") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_4") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_5"))
       {
         // Note: The 'use_joint_N' attribute can be empty, since not all robots have 6 joints (i.e. skip validation).
         robot.use_joints.push_back(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_x"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_x"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.pos.x.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         robot.base_frame.pos.x.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_y"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_y"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.pos.y.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         robot.base_frame.pos.y.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_z"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_z"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.pos.z.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         robot.base_frame.pos.z.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u0"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u0"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.rot.q1.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u1"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u1"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.rot.q2.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u2"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u2"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.rot.q3.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u3"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u3"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.rot.q4.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_coordinated"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_coordinated"))
       {
         // Note: The 'base_frame_coordinated' attribute can be empty (i.e. skip validation).
         //       It is only used if this robot's base frame is moved by another robot or single.
@@ -398,7 +415,7 @@ std::vector<cfg::moc::Robot> RWSInterface::getCFGRobots()
       }
     }
 
-     result.push_back(robot);
+    result.push_back(robot);
   }
 
   return result;
@@ -413,76 +430,86 @@ std::vector<cfg::moc::Single> RWSInterface::getCFGSingles()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::Single single;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
       {
         single.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(single.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (single.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_type"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_type"))
       {
         single.use_single_type = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(single.use_single_type.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (single.use_single_type.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint"))
       {
         single.use_joint = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(single.use_joint.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (single.use_joint.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_x"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_x"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.pos.x.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         single.base_frame.pos.x.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_y"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_y"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.pos.y.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         single.base_frame.pos.y.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_z"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_z"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.pos.z.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         single.base_frame.pos.z.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u0"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u0"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.rot.q1.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u1"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u1"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.rot.q2.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u2"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u2"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.rot.q3.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u3"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u3"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.rot.q4.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_coordinated"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_coordinated"))
       {
         // Note: The 'base_frame_coordinated' attribute can be empty (i.e. skip validation).
         //       It is only used if this single's base frame is moved by another robot or single.
@@ -505,22 +532,24 @@ std::vector<cfg::moc::Transmission> RWSInterface::getCFGTransmission()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::Transmission transmission;
 
     transmission.name = xmlNodeGetAttributeValue(instances[i], Identifiers::TITLE);
-    if(transmission.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+    if (transmission.name.empty())
+      throw std::runtime_error(EXCEPTION_PARSE_CFG);
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "rotating_move"))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "rotating_move"))
       {
         std::string temp = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(temp.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (temp.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         transmission.rotating_move = (temp == "true");
       }
     }
@@ -535,29 +564,26 @@ std::vector<RobotWareOptionInfo> RWSInterface::getPresentRobotWareOptions()
 {
   std::vector<RobotWareOptionInfo> result;
 
-  RWSResult rws_result = rws_client_.getConfigurationInstances(Identifiers::SYS,
-                                                                          Identifiers::PRESENT_OPTIONS);
+  RWSResult rws_result = rws_client_.getConfigurationInstances(Identifiers::SYS, Identifiers::PRESENT_OPTIONS);
 
   std::vector<Poco::XML::Node*> node_list = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_IA_T_LI);
 
-  for (size_t i = 0; i < node_list.size(); i+=2)
+  for (size_t i = 0; i < node_list.size(); i += 2)
   {
     if (i + 1 < node_list.size())
     {
       result.push_back(RobotWareOptionInfo(xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_VALUE),
-                                           xmlFindTextContent(node_list.at(i+1), XMLAttributes::CLASS_VALUE)));
+                                           xmlFindTextContent(node_list.at(i + 1), XMLAttributes::CLASS_VALUE)));
     }
   }
 
   return result;
 }
 
-
 std::string RWSInterface::getIOSignal(const std::string& iosignal)
 {
   return rw::io::getIOSignal(rws_client_, iosignal);
 }
-
 
 MechanicalUnitStaticInfo RWSInterface::getMechanicalUnitStaticInfo(const std::string& mechunit)
 {
@@ -565,28 +591,26 @@ MechanicalUnitStaticInfo RWSInterface::getMechanicalUnitStaticInfo(const std::st
 
   MechanicalUnitStaticInfo static_info;
   static_info.task_name = xmlFindTextContent(rws_result, XMLAttribute("class", "task-name"));
-  static_info.is_integrated_unit = xmlFindTextContent(rws_result,
-                                                      XMLAttribute("class", "is-integrated-unit"));
-  static_info.has_integrated_unit = xmlFindTextContent(rws_result,
-                                                        XMLAttribute("class", "has-integrated-unit"));
+  static_info.is_integrated_unit = xmlFindTextContent(rws_result, XMLAttribute("class", "is-integrated-unit"));
+  static_info.has_integrated_unit = xmlFindTextContent(rws_result, XMLAttribute("class", "has-integrated-unit"));
   std::string type = xmlFindTextContent(rws_result, XMLAttribute("class", "type"));
 
   // Assume mechanical unit type is undefined, update based on contents of 'type'.
   static_info.type = MechanicalUnitType::UNDEFINED;
 
-  if(type == "None")
+  if (type == "None")
   {
     static_info.type = MechanicalUnitType::NONE;
   }
-  else if(type == "TCPRobot")
+  else if (type == "TCPRobot")
   {
     static_info.type = MechanicalUnitType::TCP_ROBOT;
   }
-  else if(type == "Robot")
+  else if (type == "Robot")
   {
     static_info.type = MechanicalUnitType::ROBOT;
   }
-  else if(type == "Single")
+  else if (type == "Single")
   {
     static_info.type = MechanicalUnitType::SINGLE;
   }
@@ -598,11 +622,9 @@ MechanicalUnitStaticInfo RWSInterface::getMechanicalUnitStaticInfo(const std::st
   axes_total >> static_info.axes_total;
 
   // Basic verification.
-  if(static_info.task_name.empty() ||
-      static_info.is_integrated_unit.empty() ||
-      static_info.has_integrated_unit.empty() ||
-      static_info.type == MechanicalUnitType::UNDEFINED ||
-      axes.fail() || axes_total.fail())
+  if (static_info.task_name.empty() || static_info.is_integrated_unit.empty() ||
+      static_info.has_integrated_unit.empty() || static_info.type == MechanicalUnitType::UNDEFINED || axes.fail() ||
+      axes_total.fail())
   {
     throw std::logic_error("RWSInterface::getMechanicalUnitStaticInfo(): inconsistent data");
   }
@@ -619,10 +641,8 @@ MechanicalUnitDynamicInfo RWSInterface::getMechanicalUnitDynamicInfo(const std::
   MechanicalUnitDynamicInfo dynamic_info;
   dynamic_info.tool_name = xmlFindTextContent(rws_result, XMLAttribute("class", "tool-name"));
   dynamic_info.wobj_name = xmlFindTextContent(rws_result, XMLAttribute("class", "wobj-name"));
-  dynamic_info.payload_name = xmlFindTextContent(rws_result,
-                                                  XMLAttribute("class", "payload-name"));
-  dynamic_info.total_payload_name = xmlFindTextContent(rws_result,
-                                                        XMLAttribute("class", "total-payload-name"));
+  dynamic_info.payload_name = xmlFindTextContent(rws_result, XMLAttribute("class", "payload-name"));
+  dynamic_info.total_payload_name = xmlFindTextContent(rws_result, XMLAttribute("class", "total-payload-name"));
   dynamic_info.status = xmlFindTextContent(rws_result, XMLAttribute("class", "status"));
   dynamic_info.jog_mode = xmlFindTextContent(rws_result, XMLAttribute("class", "jog-mode"));
   std::string mode = xmlFindTextContent(rws_result, XMLAttribute("class", "mode"));
@@ -631,11 +651,11 @@ MechanicalUnitDynamicInfo RWSInterface::getMechanicalUnitDynamicInfo(const std::
   // Assume mechanical unit mode is unknown, update based on contents of 'mode'.
   dynamic_info.mode = MechanicalUnitMode::UNKNOWN_MODE;
 
-  if(mode == "Activated")
+  if (mode == "Activated")
   {
     dynamic_info.mode = MechanicalUnitMode::ACTIVATED;
   }
-  else if(mode == "Deactivated")
+  else if (mode == "Deactivated")
   {
     dynamic_info.mode = MechanicalUnitMode::DEACTIVATED;
   }
@@ -643,26 +663,22 @@ MechanicalUnitDynamicInfo RWSInterface::getMechanicalUnitDynamicInfo(const std::
   // Assume mechanical unit coordinate system is world, update based on contents of 'coord_system'.
   dynamic_info.coord_system = Coordinate::WORLD;
 
-  if(coord_system == "Base")
+  if (coord_system == "Base")
   {
     dynamic_info.coord_system = Coordinate::BASE;
   }
-  else if(coord_system == "Tool")
+  else if (coord_system == "Tool")
   {
     dynamic_info.coord_system = Coordinate::TOOL;
   }
-  else if(coord_system == "Wobj")
+  else if (coord_system == "Wobj")
   {
     dynamic_info.coord_system = Coordinate::WOBJ;
   }
 
   // Basic verification.
-  if(dynamic_info.tool_name.empty() ||
-      dynamic_info.wobj_name.empty() ||
-      dynamic_info.payload_name.empty() ||
-      dynamic_info.total_payload_name.empty() ||
-      dynamic_info.status.empty() ||
-      dynamic_info.jog_mode.empty() ||
+  if (dynamic_info.tool_name.empty() || dynamic_info.wobj_name.empty() || dynamic_info.payload_name.empty() ||
+      dynamic_info.total_payload_name.empty() || dynamic_info.status.empty() || dynamic_info.jog_mode.empty() ||
       dynamic_info.mode == MechanicalUnitMode::UNKNOWN_MODE)
   {
     throw std::logic_error("RWSInterface::getMechanicalUnitDynamicInfo: inconsistent data");
@@ -676,19 +692,18 @@ JointTarget RWSInterface::getMechanicalUnitJointTarget(const std::string& mechun
   RWSResult rws_result = rws_client_.getMechanicalUnitJointTarget(mechunit);
   std::stringstream ss;
 
-  ss << "[["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_1")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_2")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_3")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_4")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_5")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_6")) << "], ["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_a")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_b")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_c")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_d")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_e")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_f")) << "]]";
+  ss << "[[" << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_1")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_2")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_3")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_4")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_5")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_6")) << "], ["
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_a")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_b")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_c")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_d")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_e")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_f")) << "]]";
 
   JointTarget jointtarget;
   jointtarget.parseString(ss.str());
@@ -696,33 +711,30 @@ JointTarget RWSInterface::getMechanicalUnitJointTarget(const std::string& mechun
   return jointtarget;
 }
 
-RobTarget RWSInterface::getMechanicalUnitRobTarget(const std::string& mechunit,
-                                              Coordinate coordinate,
-                                              const std::string& tool,
-                                              const std::string& wobj)
+RobTarget RWSInterface::getMechanicalUnitRobTarget(const std::string& mechunit, Coordinate coordinate,
+                                                   const std::string& tool, const std::string& wobj)
 {
   RWSResult rws_result = rws_client_.getMechanicalUnitRobTarget(mechunit, coordinate, tool, wobj);
 
   std::stringstream ss;
 
-  ss << "[["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "x")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "y")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "z")) << "], ["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "q1")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "q2")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "q3")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "q4")) << "], ["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "cf1")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "cf4")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "cf6")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "cfx")) << "], ["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_a")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_b")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_c")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_d")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_e")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_f")) << "]]";
+  ss << "[[" << xmlFindTextContent(rws_result, XMLAttribute("class", "x")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "y")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "z")) << "], ["
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "q1")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "q2")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "q3")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "q4")) << "], ["
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "cf1")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "cf4")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "cf6")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "cfx")) << "], ["
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_a")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_b")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_c")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_d")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_e")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_f")) << "]]";
 
   RobTarget robtarget;
   robtarget.parseString(ss.str());
@@ -730,20 +742,16 @@ RobTarget RWSInterface::getMechanicalUnitRobTarget(const std::string& mechunit,
   return robtarget;
 }
 
-void RWSInterface::setRAPIDSymbolData(const std::string& task,
-                                      const std::string& module,
-                                      const std::string& name,
+void RWSInterface::setRAPIDSymbolData(const std::string& task, const std::string& module, const std::string& name,
                                       const std::string& data)
 {
   rw::rapid::setRAPIDSymbolData(rws_client_, RAPIDResource(task, module, name), data);
 }
 
-
 void RWSInterface::setRAPIDSymbolData(RAPIDResource const& resource, const RAPIDSymbolDataAbstract& data)
 {
   rw::rapid::setRAPIDSymbolData(rws_client_, resource, data);
 }
-
 
 void RWSInterface::startRAPIDExecution()
 {
@@ -809,8 +817,7 @@ SystemInfo RWSInterface::getSystemInfo()
     result.system_options.push_back(xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_OPTION));
   }
 
-  result.system_type = xmlFindTextContent(rws_client_.getContollerService(),
-                                          XMLAttributes::CLASS_CTRL_TYPE);
+  result.system_type = xmlFindTextContent(rws_client_.getContollerService(), XMLAttributes::CLASS_CTRL_TYPE);
 
   return result;
 }
@@ -835,19 +842,16 @@ void RWSInterface::setIOSignal(const std::string& iosignal, const std::string& v
   rw::io::setIOSignal(rws_client_, iosignal, value);
 }
 
-std::string RWSInterface::getRAPIDSymbolData(const std::string& task,
-                                             const std::string& module,
+std::string RWSInterface::getRAPIDSymbolData(const std::string& task, const std::string& module,
                                              const std::string& name)
 {
   return rw::rapid::getRAPIDSymbolData(rws_client_, RAPIDResource(task, module, name));
 }
 
-
 void RWSInterface::getRAPIDSymbolData(RAPIDResource const& resource, RAPIDSymbolDataAbstract& data)
 {
   rw::rapid::getRAPIDSymbolData(rws_client_, resource, data);
 }
-
 
 void RWSInterface::loadModuleIntoTask(const std::string& task, const FileResource& resource, const bool replace)
 {
@@ -874,73 +878,62 @@ void RWSInterface::deleteFile(const FileResource& resource)
   rws_client_.deleteFile(resource);
 }
 
-SubscriptionGroup RWSInterface::openSubscription (const SubscriptionResources& resources)
+SubscriptionGroup RWSInterface::openSubscription(const SubscriptionResources& resources)
 {
-  return SubscriptionGroup {rws_client_, resources};
+  return SubscriptionGroup{ rws_client_, resources };
 }
 
-void RWSInterface::registerLocalUser(const std::string& username,
-                                     const std::string& application,
+void RWSInterface::registerLocalUser(const std::string& username, const std::string& application,
                                      const std::string& location)
 {
   rws_client_.registerLocalUser(username, application, location);
 }
 
-void RWSInterface::registerRemoteUser(const std::string& username,
-                                      const std::string& application,
+void RWSInterface::registerRemoteUser(const std::string& username, const std::string& application,
                                       const std::string& location)
 {
   rws_client_.registerRemoteUser(username, application, location);
 }
-
 
 void RWSInterface::setDigitalSignal(std::string const& signal_name, bool value)
 {
   rw::io::setDigitalSignal(rws_client_, signal_name, value);
 }
 
-
 void RWSInterface::setAnalogSignal(std::string const& signal_name, float value)
 {
   rw::io::setAnalogSignal(rws_client_, signal_name, value);
 }
-
 
 void RWSInterface::setGroupSignal(std::string const& signal_name, std::uint32_t value)
 {
   rw::io::setGroupSignal(rws_client_, signal_name, value);
 }
 
-
 bool RWSInterface::getDigitalSignal(std::string const& signal_name)
 {
   return rw::io::getDigitalSignal(rws_client_, signal_name);
 }
-
 
 float RWSInterface::getAnalogSignal(std::string const& signal_name)
 {
   return rw::io::getAnalogSignal(rws_client_, signal_name);
 }
 
-
 std::uint32_t RWSInterface::getGroupSignal(std::string const& signal_name)
 {
   return rw::io::getGroupSignal(rws_client_, signal_name);
 }
-
 
 rw::io::IOSignalInfo RWSInterface::getIOSignals()
 {
   return rw::io::getIOSignals(rws_client_);
 }
 
-
 void RWSInterface::requestMastership()
 {
   rws_client_.httpPost("/rw/mastership?action=request");
 }
-
 
 void RWSInterface::requestMastership(MastershipDomain domain)
 {
@@ -950,12 +943,10 @@ void RWSInterface::requestMastership(MastershipDomain domain)
   rws_client_.httpPost(uri.str());
 }
 
-
 void RWSInterface::releaseMastership()
 {
   rws_client_.httpPost("/rw/mastership?action=release");
 }
-
 
 void RWSInterface::releaseMastership(MastershipDomain domain)
 {
@@ -965,28 +956,24 @@ void RWSInterface::releaseMastership(MastershipDomain domain)
   rws_client_.httpPost(uri.str());
 }
 
-
 void RWSInterface::activateAllTasks()
 {
   rws_client_.httpPost("/rw/rapid/tasks?action=activate");
 }
-
 
 void RWSInterface::deactivateAllTasks()
 {
   rws_client_.httpPost("/rw/rapid/tasks?action=deactivate");
 }
 
-
 /************************************************************
  * Auxiliary methods
  */
 
-bool RWSInterface::compareSingleContent(const RWSResult& rws_result,
-                                           const XMLAttribute& attribute,
-                                           const std::string& compare_string)
+bool RWSInterface::compareSingleContent(const RWSResult& rws_result, const XMLAttribute& attribute,
+                                        const std::string& compare_string)
 {
   return xmlFindTextContent(rws_result, attribute) == compare_string;
 }
 
-}
+}  // namespace abb::rws::v1_0

--- a/src/v2_0/rw/panel.cpp
+++ b/src/v2_0/rw/panel.cpp
@@ -4,72 +4,67 @@
 #include <abb_librws/parsing.h>
 #include <abb_librws/system_constants.h>
 
-
-namespace abb :: rws :: v2_0 :: rw :: panel
+namespace abb ::rws ::v2_0 ::rw ::panel
 {
-    ControllerState getControllerState(RWSClient& client)
-    {
-        std::string uri = Resources::RW_PANEL_CTRLSTATE;
-        RWSResult xml_content = parseXml(client.httpGet(uri).content());
+ControllerState getControllerState(RWSClient& client)
+{
+  std::string uri = Resources::RW_PANEL_CTRLSTATE;
+  RWSResult xml_content = parseXml(client.httpGet(uri).content());
 
-        Poco::XML::Node const * li_node = xml_content->getNodeByPath("html/body/div/ul/li");
-        if (!li_node)
-            BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS response: can't find XML path html/body/div/ul/li"});
+  Poco::XML::Node const* li_node = xml_content->getNodeByPath("html/body/div/ul/li");
+  if (!li_node)
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS response: can't find XML path html/body/div/ul/li" });
 
-        std::string const ctrlstate = xmlFindTextContent(li_node, XMLAttributes::CLASS_CTRLSTATE);
-        if (ctrlstate.empty())
-            BOOST_THROW_EXCEPTION(ProtocolError {"Can't find a node with class=\"ctrlstate\""});
+  std::string const ctrlstate = xmlFindTextContent(li_node, XMLAttributes::CLASS_CTRLSTATE);
+  if (ctrlstate.empty())
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Can't find a node with class=\"ctrlstate\"" });
 
-        return makeControllerState(ctrlstate);
-    }
-
-
-    OperationMode getOperationMode(RWSClient& client)
-    {
-        std::string uri = Resources::RW_PANEL_OPMODE;
-        RWSResult xml_content = parseXml(client.httpGet(uri).content());
-
-        Poco::XML::Node const * li_node = xml_content->getNodeByPath("html/body/div/ul/li");
-        if (!li_node)
-            BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS response: can't find XML path html/body/div/ul/li"});
-
-        std::string const opmode = xmlFindTextContent(li_node, XMLAttributes::CLASS_OPMODE);
-        if (opmode.empty())
-            BOOST_THROW_EXCEPTION(ProtocolError {"Can't find a node with class=\"opmode\""});
-
-        return makeOperationMode(opmode);
-    }
-
-
-    void setControllerState(RWSClient& client, ControllerState state)
-    {
-        std::string uri = Resources::RW_PANEL_CTRLSTATE;
-        std::stringstream content;
-        content << "ctrl-state=" << state;
-        std::string content_type = "application/x-www-form-urlencoded;v=2.0";
-
-        client.httpPost(uri, content.str(), content_type);
-    }
-
-
-    unsigned getSpeedRatio(RWSClient& client)
-    {
-        std::string uri = "/rw/panel/speedratio";
-        RWSResult rws_result = parseXml(client.httpGet(uri).content());
-
-        return std::stoul(xmlFindTextContent(rws_result, XMLAttribute(Identifiers::CLASS, "speedratio")));
-    }
-
-
-    void setSpeedRatio(RWSClient& client, unsigned int ratio)
-    {
-        if (ratio > 100)
-            BOOST_THROW_EXCEPTION(std::out_of_range {"Speed ratio argument out of range (should be 0 <= ratio <= 100)"});
-
-        std::string uri = "/rw/panel/speedratio?action=setspeedratio";
-        std::stringstream content;
-        content << "speed-ratio=" << ratio;
-
-        client.httpPost(uri, content.str());
-    }
+  return makeControllerState(ctrlstate);
 }
+
+OperationMode getOperationMode(RWSClient& client)
+{
+  std::string uri = Resources::RW_PANEL_OPMODE;
+  RWSResult xml_content = parseXml(client.httpGet(uri).content());
+
+  Poco::XML::Node const* li_node = xml_content->getNodeByPath("html/body/div/ul/li");
+  if (!li_node)
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS response: can't find XML path html/body/div/ul/li" });
+
+  std::string const opmode = xmlFindTextContent(li_node, XMLAttributes::CLASS_OPMODE);
+  if (opmode.empty())
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Can't find a node with class=\"opmode\"" });
+
+  return makeOperationMode(opmode);
+}
+
+void setControllerState(RWSClient& client, ControllerState state)
+{
+  std::string uri = Resources::RW_PANEL_CTRLSTATE;
+  std::stringstream content;
+  content << "ctrl-state=" << state;
+  std::string content_type = "application/x-www-form-urlencoded;v=2.0";
+
+  client.httpPost(uri, content.str(), content_type);
+}
+
+unsigned getSpeedRatio(RWSClient& client)
+{
+  std::string uri = "/rw/panel/speedratio";
+  RWSResult rws_result = parseXml(client.httpGet(uri).content());
+
+  return std::stoul(xmlFindTextContent(rws_result, XMLAttribute(Identifiers::CLASS, "speedratio")));
+}
+
+void setSpeedRatio(RWSClient& client, unsigned int ratio)
+{
+  if (ratio > 100)
+    BOOST_THROW_EXCEPTION(std::out_of_range{ "Speed ratio argument out of range (should be 0 <= ratio <= 100)" });
+
+  std::string uri = "/rw/panel/speedratio?action=setspeedratio";
+  std::stringstream content;
+  content << "speed-ratio=" << ratio;
+
+  client.httpPost(uri, content.str());
+}
+}  // namespace abb::rws::v2_0::rw::panel

--- a/src/v2_0/rw/rapid.cpp
+++ b/src/v2_0/rw/rapid.cpp
@@ -4,257 +4,243 @@
 #include <abb_librws/parsing.h>
 #include <abb_librws/system_constants.h>
 
-
-namespace abb :: rws :: v2_0 :: rw :: rapid
+namespace abb ::rws ::v2_0 ::rw ::rapid
 {
-    /**
-     * \brief A method for retrieving the properties of a RAPID symbol.
-     *
-     * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
-     *
-     * \return RWSResult containing the result.
-     *
-     * \throw \a RWSError if something goes wrong.
-     */
-    static RWSResult getRAPIDSymbolProperties(RWSClient& client, RAPIDResource const& resource);
+/**
+ * \brief A method for retrieving the properties of a RAPID symbol.
+ *
+ * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
+ *
+ * \return RWSResult containing the result.
+ *
+ * \throw \a RWSError if something goes wrong.
+ */
+static RWSResult getRAPIDSymbolProperties(RWSClient& client, RAPIDResource const& resource);
 
-    /**
-     * \brief Method for generating a RAPID data resource URI path.
-     *
-     * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
-     *
-     * \return std::string containing the path.
-     */
-    static std::string generateRAPIDDataPath(const RAPIDResource& resource);
+/**
+ * \brief Method for generating a RAPID data resource URI path.
+ *
+ * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
+ *
+ * \return std::string containing the path.
+ */
+static std::string generateRAPIDDataPath(const RAPIDResource& resource);
 
-    /**
-     * \brief Method for generating a RAPID properties resource URI path.
-     *
-     * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
-     *
-     * \return std::string containing the path.
-     */
-    static std::string generateRAPIDPropertiesPath(const RAPIDResource& resource);
+/**
+ * \brief Method for generating a RAPID properties resource URI path.
+ *
+ * \param resource specifying the RAPID task, module and symbol names for the RAPID resource.
+ *
+ * \return std::string containing the path.
+ */
+static std::string generateRAPIDPropertiesPath(const RAPIDResource& resource);
 
-    /**
-     * \brief Method for generating a task resource URI path.
-     *
-     * \param task for the task name.
-     *
-     * \return std::string containing the path.
-     */
-    static std::string generateRAPIDTasksPath(const std::string& task);
+/**
+ * \brief Method for generating a task resource URI path.
+ *
+ * \param task for the task name.
+ *
+ * \return std::string containing the path.
+ */
+static std::string generateRAPIDTasksPath(const std::string& task);
 
+RAPIDExecutionInfo getRAPIDExecution(RWSClient& client)
+{
+  RAPIDExecutionInfo result;
 
-    RAPIDExecutionInfo getRAPIDExecution(RWSClient& client)
-    {
-        RAPIDExecutionInfo result;
+  std::string const uri = Resources::RW_RAPID_EXECUTION;
+  RWSResult xml_content = parseXml(client.httpGet(uri).content());
 
-        std::string const uri = Resources::RW_RAPID_EXECUTION;
-        RWSResult xml_content = parseXml(client.httpGet(uri).content());
+  Poco::XML::Node const* li_node = xml_content->getNodeByPath("html/body/div/ul/li");
+  if (!li_node)
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS response: can't find XML path html/body/div/ul/li" });
 
-        Poco::XML::Node const * li_node = xml_content->getNodeByPath("html/body/div/ul/li");
-        if (!li_node)
-            BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS response: can't find XML path html/body/div/ul/li"});
+  std::string const ctrlexecstate = xmlFindTextContent(li_node, XMLAttributes::CLASS_CTRLEXECSTATE);
+  if (ctrlexecstate.empty())
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Can't find a node with class=\"ctrlexecstate\"" });
 
-        std::string const ctrlexecstate = xmlFindTextContent(li_node, XMLAttributes::CLASS_CTRLEXECSTATE);
-        if (ctrlexecstate.empty())
-            BOOST_THROW_EXCEPTION(ProtocolError {"Can't find a node with class=\"ctrlexecstate\""});
+  std::string const cycle = xmlFindTextContent(li_node, XMLAttribute{ "class", "cycle" });
+  if (cycle.empty())
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Can't find a node with class=\"cycle\"" });
 
-        std::string const cycle = xmlFindTextContent(li_node, XMLAttribute {"class", "cycle"});
-        if (cycle.empty())
-            BOOST_THROW_EXCEPTION(ProtocolError {"Can't find a node with class=\"cycle\""});
-
-        return RAPIDExecutionInfo {
-            makeRAPIDExecutionState(ctrlexecstate),
-            makeRAPIDRunMode(cycle)
-        };
-    }
-
-
-    void startRAPIDExecution(RWSClient& client, Mastership const& mastership)
-    {
-        std::stringstream uri;
-        uri << "/rw/rapid/execution/start?mastership=" << mastership;
-        std::string const content = "regain=continue&execmode=continue&cycle=forever&condition=none&stopatbp=disabled&alltaskbytsp=false";
-        std::string const content_type = "application/x-www-form-urlencoded;v=2.0";
-
-        client.httpPost(uri.str(), content, content_type);
-    }
-
-
-    void stopRAPIDExecution(RWSClient& client, StopMode stopmode, UseTsp usetsp)
-    {
-        std::string const uri = Resources::RW_RAPID_EXECUTION + "/" + Queries::ACTION_STOP;
-        std::string const content = "stopmode=stop";
-        std::string const content_type = "application/x-www-form-urlencoded;v=2.0";
-
-        client.httpPost(uri, content, content_type);
-    }
-
-
-    void resetRAPIDProgramPointer(RWSClient& client, Mastership const& mastership)
-    {
-        std::stringstream uri;
-        uri << Resources::RW_RAPID_EXECUTION << "/" << Queries::ACTION_RESETPP << "?mastership=" << mastership;
-        std::string content_type = "application/x-www-form-urlencoded;v=2.0";
-
-        client.httpPost(uri.str(), "", content_type);
-    }
-
-
-    void getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource, RAPIDSymbolDataAbstract& data)
-    {
-        RWSResult const temp_result = getRAPIDSymbolProperties(client, resource);
-        std::string const data_type = xmlFindTextContent(temp_result, XMLAttributes::CLASS_DATTYP);
-
-        if (data.getType() == data_type)
-            data.parseString(getRAPIDSymbolData(client, resource));
-        else
-            BOOST_THROW_EXCEPTION(std::invalid_argument {"Argument type does not match the RAPID variable type"});
-    }
-
-
-    void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const RAPIDSymbolDataAbstract& data,
-        bool initval, bool log, Mastership const& mastership)
-    {
-        setRAPIDSymbolData(client, resource, data.constructString(), initval, log, mastership);
-    }
-
-
-    std::string getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource)
-    {
-        std::string const uri = generateRAPIDDataPath(resource);
-        RWSResult xml_content = parseXml(client.httpGet(uri).content());
-        std::string value = xmlFindTextContent(xml_content, XMLAttributes::CLASS_VALUE);
-
-        if (value.empty())
-            BOOST_THROW_EXCEPTION(std::logic_error {"RAPID value string was empty"});
-
-        return value;
-    }
-
-
-    void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const std::string& data,
-        bool initval, bool log, Mastership const& mastership)
-    {
-        std::stringstream uri;
-        uri << std::boolalpha << generateRAPIDDataPath(resource) << "?initval=" << initval << "&log=" << log << "&mastership=" << mastership;
-        std::string const content = Identifiers::VALUE + "=" + data;
-        std::string const content_type = "application/x-www-form-urlencoded;v=2.0";
-
-        client.httpPost(uri.str(), content, content_type);
-    }
-
-
-    static RWSResult getRAPIDSymbolProperties(RWSClient& client, RAPIDResource const& resource)
-    {
-        std::string const uri = generateRAPIDPropertiesPath(resource);
-        return parseXml(client.httpGet(uri).content());
-    }
-
-
-    static std::string generateRAPIDDataPath(const RAPIDResource& resource)
-    {
-        return Resources::RW_RAPID_SYMBOL_DATA_RAPID + "/" + resource.task + "/" + resource.module + "/" + resource.name + "/data";
-    }
-
-
-    static std::string generateRAPIDPropertiesPath(const RAPIDResource& resource)
-    {
-        return Resources::RW_RAPID_SYMBOL_PROPERTIES_RAPID + "/" + resource.task + "/" + resource.module + "/"+ resource.name + "/properties";
-    }
-
-
-    std::vector<RAPIDModuleInfo> getRAPIDModulesInfo(RWSClient& client, const std::string& task)
-    {
-        std::vector<RAPIDModuleInfo> result;
-
-        std::string const uri = "/rw/rapid/tasks/" + task + "/modules";
-        RWSResult const rws_result = parseXml(client.httpGet(uri).content());
-        std::vector<Poco::XML::Node*> node_list = xmlFindNodes(rws_result,
-                                                                XMLAttributes::CLASS_RAP_MODULE_INFO_LI);
-
-        for (size_t i = 0; i < node_list.size(); ++i)
-        {
-            std::string name = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_NAME);
-            std::string type = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_TYPE);
-
-            result.push_back(RAPIDModuleInfo(name, type));
-        }
-
-        return result;
-    }
-
-    std::vector<RAPIDTaskInfo> getRAPIDTasks(RWSClient& client)
-    {
-        std::vector<RAPIDTaskInfo> result;
-
-        RWSResult const rws_result = parseXml(client.httpGet(Resources::RW_RAPID_TASKS).content());
-        std::vector<Poco::XML::Node*> node_list = xmlFindNodes(rws_result, XMLAttributes::CLASS_RAP_TASK_LI);
-
-        for (size_t i = 0; i < node_list.size(); ++i)
-        {
-            std::string name = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_NAME);
-            bool is_motion_task = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_MOTIONTASK) == SystemConstants::RAPID::RAPID_TRUE;
-            bool is_active = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_ACTIVE) == "On";
-            std::string temp = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_EXCSTATE);
-
-            // Assume task state is unknown, update based on contents of 'temp'.
-            RAPIDTaskExecutionState execution_state = RAPIDTaskExecutionState::UNKNOWN;
-
-            if(temp == "read")
-            {
-                execution_state = RAPIDTaskExecutionState::READY;
-            }
-            else if(temp == "stop")
-            {
-                execution_state = RAPIDTaskExecutionState::STOPPED;
-            }
-            else if(temp == "star")
-            {
-                execution_state = RAPIDTaskExecutionState::STARTED;
-            }
-            else if(temp == "unin")
-            {
-                execution_state = RAPIDTaskExecutionState::UNINITIALIZED;
-            }
-
-            result.push_back(RAPIDTaskInfo(name, is_motion_task, is_active, execution_state));
-        }
-
-        return result;
-    }
-
-
-    void loadModuleIntoTask(RWSClient& client, const std::string& task, const FileResource& resource, const bool replace, Mastership const& mastership)
-    {
-        std::stringstream uri;
-        uri << generateRAPIDTasksPath(task) << "/" << Queries::ACTION_LOAD_MODULE << "?mastership=" << mastership;
-
-        // Path to file should be a direct path, i.e. without "/fileservice/"
-        std::string content =
-            Identifiers::MODULEPATH + "=" + resource.directory + "/" + resource.filename +
-            "&replace=" + ((replace) ? "true" : "false");
-        std::string content_type = "application/x-www-form-urlencoded;v=2.0";
-
-        client.httpPost(uri.str(), content, content_type);
-    }
-
-
-    void unloadModuleFromTask(RWSClient& client, const std::string& task, const std::string& module_name, Mastership const& mastership)
-    {
-        std::stringstream uri;
-        uri << generateRAPIDTasksPath(task) << "/" + Queries::ACTION_UNLOAD_MODULE << "?mastership=" << mastership;
-        std::string content = Identifiers::MODULE + "=" + module_name;
-        std::string content_type = "application/x-www-form-urlencoded;v=2.0";
-
-        client.httpPost(uri.str(), content, content_type);
-    }
-
-
-    static std::string generateRAPIDTasksPath(const std::string& task)
-    {
-        return Resources::RW_RAPID_TASKS + "/" + task;
-    }
+  return RAPIDExecutionInfo{ makeRAPIDExecutionState(ctrlexecstate), makeRAPIDRunMode(cycle) };
 }
+
+void startRAPIDExecution(RWSClient& client, Mastership const& mastership)
+{
+  std::stringstream uri;
+  uri << "/rw/rapid/execution/start?mastership=" << mastership;
+  std::string const content =
+      "regain=continue&execmode=continue&cycle=forever&condition=none&stopatbp=disabled&alltaskbytsp=false";
+  std::string const content_type = "application/x-www-form-urlencoded;v=2.0";
+
+  client.httpPost(uri.str(), content, content_type);
+}
+
+void stopRAPIDExecution(RWSClient& client, StopMode stopmode, UseTsp usetsp)
+{
+  std::string const uri = Resources::RW_RAPID_EXECUTION + "/" + Queries::ACTION_STOP;
+  std::string const content = "stopmode=stop";
+  std::string const content_type = "application/x-www-form-urlencoded;v=2.0";
+
+  client.httpPost(uri, content, content_type);
+}
+
+void resetRAPIDProgramPointer(RWSClient& client, Mastership const& mastership)
+{
+  std::stringstream uri;
+  uri << Resources::RW_RAPID_EXECUTION << "/" << Queries::ACTION_RESETPP << "?mastership=" << mastership;
+  std::string content_type = "application/x-www-form-urlencoded;v=2.0";
+
+  client.httpPost(uri.str(), "", content_type);
+}
+
+void getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource, RAPIDSymbolDataAbstract& data)
+{
+  RWSResult const temp_result = getRAPIDSymbolProperties(client, resource);
+  std::string const data_type = xmlFindTextContent(temp_result, XMLAttributes::CLASS_DATTYP);
+
+  if (data.getType() == data_type)
+    data.parseString(getRAPIDSymbolData(client, resource));
+  else
+    BOOST_THROW_EXCEPTION(std::invalid_argument{ "Argument type does not match the RAPID variable type" });
+}
+
+void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const RAPIDSymbolDataAbstract& data,
+                        bool initval, bool log, Mastership const& mastership)
+{
+  setRAPIDSymbolData(client, resource, data.constructString(), initval, log, mastership);
+}
+
+std::string getRAPIDSymbolData(RWSClient& client, RAPIDResource const& resource)
+{
+  std::string const uri = generateRAPIDDataPath(resource);
+  RWSResult xml_content = parseXml(client.httpGet(uri).content());
+  std::string value = xmlFindTextContent(xml_content, XMLAttributes::CLASS_VALUE);
+
+  if (value.empty())
+    BOOST_THROW_EXCEPTION(std::logic_error{ "RAPID value string was empty" });
+
+  return value;
+}
+
+void setRAPIDSymbolData(RWSClient& client, const RAPIDResource& resource, const std::string& data, bool initval,
+                        bool log, Mastership const& mastership)
+{
+  std::stringstream uri;
+  uri << std::boolalpha << generateRAPIDDataPath(resource) << "?initval=" << initval << "&log=" << log
+      << "&mastership=" << mastership;
+  std::string const content = Identifiers::VALUE + "=" + data;
+  std::string const content_type = "application/x-www-form-urlencoded;v=2.0";
+
+  client.httpPost(uri.str(), content, content_type);
+}
+
+static RWSResult getRAPIDSymbolProperties(RWSClient& client, RAPIDResource const& resource)
+{
+  std::string const uri = generateRAPIDPropertiesPath(resource);
+  return parseXml(client.httpGet(uri).content());
+}
+
+static std::string generateRAPIDDataPath(const RAPIDResource& resource)
+{
+  return Resources::RW_RAPID_SYMBOL_DATA_RAPID + "/" + resource.task + "/" + resource.module + "/" + resource.name +
+         "/data";
+}
+
+static std::string generateRAPIDPropertiesPath(const RAPIDResource& resource)
+{
+  return Resources::RW_RAPID_SYMBOL_PROPERTIES_RAPID + "/" + resource.task + "/" + resource.module + "/" +
+         resource.name + "/properties";
+}
+
+std::vector<RAPIDModuleInfo> getRAPIDModulesInfo(RWSClient& client, const std::string& task)
+{
+  std::vector<RAPIDModuleInfo> result;
+
+  std::string const uri = "/rw/rapid/tasks/" + task + "/modules";
+  RWSResult const rws_result = parseXml(client.httpGet(uri).content());
+  std::vector<Poco::XML::Node*> node_list = xmlFindNodes(rws_result, XMLAttributes::CLASS_RAP_MODULE_INFO_LI);
+
+  for (size_t i = 0; i < node_list.size(); ++i)
+  {
+    std::string name = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_NAME);
+    std::string type = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_TYPE);
+
+    result.push_back(RAPIDModuleInfo(name, type));
+  }
+
+  return result;
+}
+
+std::vector<RAPIDTaskInfo> getRAPIDTasks(RWSClient& client)
+{
+  std::vector<RAPIDTaskInfo> result;
+
+  RWSResult const rws_result = parseXml(client.httpGet(Resources::RW_RAPID_TASKS).content());
+  std::vector<Poco::XML::Node*> node_list = xmlFindNodes(rws_result, XMLAttributes::CLASS_RAP_TASK_LI);
+
+  for (size_t i = 0; i < node_list.size(); ++i)
+  {
+    std::string name = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_NAME);
+    bool is_motion_task =
+        xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_MOTIONTASK) == SystemConstants::RAPID::RAPID_TRUE;
+    bool is_active = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_ACTIVE) == "On";
+    std::string temp = xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_EXCSTATE);
+
+    // Assume task state is unknown, update based on contents of 'temp'.
+    RAPIDTaskExecutionState execution_state = RAPIDTaskExecutionState::UNKNOWN;
+
+    if (temp == "read")
+    {
+      execution_state = RAPIDTaskExecutionState::READY;
+    }
+    else if (temp == "stop")
+    {
+      execution_state = RAPIDTaskExecutionState::STOPPED;
+    }
+    else if (temp == "star")
+    {
+      execution_state = RAPIDTaskExecutionState::STARTED;
+    }
+    else if (temp == "unin")
+    {
+      execution_state = RAPIDTaskExecutionState::UNINITIALIZED;
+    }
+
+    result.push_back(RAPIDTaskInfo(name, is_motion_task, is_active, execution_state));
+  }
+
+  return result;
+}
+
+void loadModuleIntoTask(RWSClient& client, const std::string& task, const FileResource& resource, const bool replace,
+                        Mastership const& mastership)
+{
+  std::stringstream uri;
+  uri << generateRAPIDTasksPath(task) << "/" << Queries::ACTION_LOAD_MODULE << "?mastership=" << mastership;
+
+  // Path to file should be a direct path, i.e. without "/fileservice/"
+  std::string content = Identifiers::MODULEPATH + "=" + resource.directory + "/" + resource.filename +
+                        "&replace=" + ((replace) ? "true" : "false");
+  std::string content_type = "application/x-www-form-urlencoded;v=2.0";
+
+  client.httpPost(uri.str(), content, content_type);
+}
+
+void unloadModuleFromTask(RWSClient& client, const std::string& task, const std::string& module_name,
+                          Mastership const& mastership)
+{
+  std::stringstream uri;
+  uri << generateRAPIDTasksPath(task) << "/" + Queries::ACTION_UNLOAD_MODULE << "?mastership=" << mastership;
+  std::string content = Identifiers::MODULE + "=" + module_name;
+  std::string content_type = "application/x-www-form-urlencoded;v=2.0";
+
+  client.httpPost(uri.str(), content, content_type);
+}
+
+static std::string generateRAPIDTasksPath(const std::string& task)
+{
+  return Resources::RW_RAPID_TASKS + "/" + task;
+}
+}  // namespace abb::rws::v2_0::rw::rapid

--- a/src/v2_0/rws.cpp
+++ b/src/v2_0/rws.cpp
@@ -5,131 +5,130 @@
 #include <iostream>
 #include <stdexcept>
 
-
-namespace abb :: rws :: v2_0
+namespace abb ::rws ::v2_0
 {
-  const std::string Identifiers::ACTIVE                         = "active";
-  const std::string Identifiers::ARM                            = "arm";
-  const std::string Identifiers::CFG_DT_INSTANCE_LI             = "cfg-dt-instance-li";
-  const std::string Identifiers::CFG_IA_T_LI                    = "cfg-ia-t-li";
-  const std::string Identifiers::CTRL_TYPE                      = "ctrl-type";
-  const std::string Identifiers::CTRLEXECSTATE                  = "ctrlexecstate";
-  const std::string Identifiers::CTRLSTATE                      = "ctrlstate";
-  const std::string Identifiers::DATTYP                         = "dattyp";
-  const std::string Identifiers::EXCSTATE                       = "excstate";
-  const std::string Identifiers::IOS_SIGNAL                     = "ios-signal";
-  const std::string Identifiers::HOME_DIRECTORY                 = "$home";
-  const std::string Identifiers::LVALUE                         = "lvalue";
-  const std::string Identifiers::MECHANICAL_UNIT                = "mechanical_unit";
-  const std::string Identifiers::MECHANICAL_UNIT_GROUP          = "mechanical_unit_group";
-  const std::string Identifiers::MOC                            = "moc";
-  const std::string Identifiers::MODULE                         = "module";
-  const std::string Identifiers::MODULEPATH                     = "modulepath";
-  const std::string Identifiers::MOTIONTASK                     = "motiontask";
-  const std::string Identifiers::NAME                           = "name";
-  const std::string Identifiers::OPMODE                         = "opmode";
-  const std::string Identifiers::PRESENT_OPTIONS                = "present_options";
-  const std::string Identifiers::RAP_MODULE_INFO_LI             = "rap-module-info-li";
-  const std::string Identifiers::RAP_TASK_LI                    = "rap-task-li";
-  const std::string Identifiers::ROBOT                          = "robot";
-  const std::string Identifiers::RW_VERSION_NAME                = "rwversionname";
-  const std::string Identifiers::SINGLE                         = "single";
-  const std::string Identifiers::STATE                          = "state";
-  const std::string Identifiers::SYS                            = "sys";
-  const std::string Identifiers::SYS_OPTION_LI                  = "sys-option-li";
-  const std::string Identifiers::SYS_SYSTEM_LI                  = "sys-system-li";
-  const std::string Identifiers::TITLE                          = "title";
-  const std::string Identifiers::TYPE                           = "type";
-  const std::string Identifiers::VALUE                          = "value";
-  const std::string Identifiers::CLASS                          = "class";
-  const std::string Identifiers::OPTION                         = "option";
-  const std::string Queries::ACTION_LOAD_MODULE                 = "loadmod";
-  const std::string Queries::ACTION_RELEASE                     = "action=release";
-  const std::string Queries::ACTION_REQUEST                     = "action=request";
-  const std::string Queries::ACTION_RESETPP                     = "resetpp";
-  const std::string Queries::ACTION_SET                         = "set-value";
-  const std::string Queries::ACTION_SETCTRLSTATE                = "action=setctrlstate";  // TODO remove
-  const std::string Queries::ACTION_SET_LOCALE                  = "action=set-locale";
-  const std::string Queries::ACTION_START                       = "start";
-  const std::string Queries::ACTION_STOP                        = "stop";
-  const std::string Queries::ACTION_UNLOAD_MODULE               = "unloadmod";
-  const std::string Queries::TASK                               = "task=";
-  const std::string Services::CTRL                              = "/ctrl";
-  const std::string Services::FILESERVICE                       = "/fileservice";
-  const std::string Services::RW                                = "/rw";
-  const std::string Services::SUBSCRIPTION                      = "/subscription";
-  const std::string Services::USERS                             = "/users";
-  const std::string Resources::INSTANCES                        = "/instances";
-  const std::string Resources::JOINTTARGET                      = "/jointtarget";
-  const std::string Resources::LOGOUT                           = "/logout";
-  const std::string Resources::ROBTARGET                        = "/robtarget";
-  const std::string Resources::RW_CFG                           = Services::RW + "/cfg";
-  const std::string Resources::RW_IOSYSTEM_SIGNALS              = Services::RW + "/iosystem/signals";
-  const std::string Resources::RW_MOTIONSYSTEM_MECHUNITS        = Services::RW + "/motionsystem/mechunits";
-  const std::string Resources::RW_PANEL_CTRLSTATE               = Services::RW + "/panel/ctrl-state";
-  const std::string Resources::RW_PANEL_OPMODE                  = Services::RW + "/panel/opmode";
-  const std::string Resources::RW_RAPID_EXECUTION               = Services::RW + "/rapid/execution";
-  const std::string Resources::RW_RAPID_MODULES                 = Services::RW + "/rapid/modules";
-  const std::string Resources::RW_RAPID_SYMBOL_DATA_RAPID       = Services::RW + "/rapid/symbol/RAPID";
-  const std::string Resources::RW_RAPID_SYMBOL_PROPERTIES_RAPID = Services::RW + "/rapid/symbol/RAPID";   // TODO merge with symbol data
-  const std::string Resources::RW_RAPID_TASKS                   = Services::RW + "/rapid/tasks";
-  const std::string Resources::RW_SYSTEM                        = Services::RW + "/system";
+const std::string Identifiers::ACTIVE = "active";
+const std::string Identifiers::ARM = "arm";
+const std::string Identifiers::CFG_DT_INSTANCE_LI = "cfg-dt-instance-li";
+const std::string Identifiers::CFG_IA_T_LI = "cfg-ia-t-li";
+const std::string Identifiers::CTRL_TYPE = "ctrl-type";
+const std::string Identifiers::CTRLEXECSTATE = "ctrlexecstate";
+const std::string Identifiers::CTRLSTATE = "ctrlstate";
+const std::string Identifiers::DATTYP = "dattyp";
+const std::string Identifiers::EXCSTATE = "excstate";
+const std::string Identifiers::IOS_SIGNAL = "ios-signal";
+const std::string Identifiers::HOME_DIRECTORY = "$home";
+const std::string Identifiers::LVALUE = "lvalue";
+const std::string Identifiers::MECHANICAL_UNIT = "mechanical_unit";
+const std::string Identifiers::MECHANICAL_UNIT_GROUP = "mechanical_unit_group";
+const std::string Identifiers::MOC = "moc";
+const std::string Identifiers::MODULE = "module";
+const std::string Identifiers::MODULEPATH = "modulepath";
+const std::string Identifiers::MOTIONTASK = "motiontask";
+const std::string Identifiers::NAME = "name";
+const std::string Identifiers::OPMODE = "opmode";
+const std::string Identifiers::PRESENT_OPTIONS = "present_options";
+const std::string Identifiers::RAP_MODULE_INFO_LI = "rap-module-info-li";
+const std::string Identifiers::RAP_TASK_LI = "rap-task-li";
+const std::string Identifiers::ROBOT = "robot";
+const std::string Identifiers::RW_VERSION_NAME = "rwversionname";
+const std::string Identifiers::SINGLE = "single";
+const std::string Identifiers::STATE = "state";
+const std::string Identifiers::SYS = "sys";
+const std::string Identifiers::SYS_OPTION_LI = "sys-option-li";
+const std::string Identifiers::SYS_SYSTEM_LI = "sys-system-li";
+const std::string Identifiers::TITLE = "title";
+const std::string Identifiers::TYPE = "type";
+const std::string Identifiers::VALUE = "value";
+const std::string Identifiers::CLASS = "class";
+const std::string Identifiers::OPTION = "option";
+const std::string Queries::ACTION_LOAD_MODULE = "loadmod";
+const std::string Queries::ACTION_RELEASE = "action=release";
+const std::string Queries::ACTION_REQUEST = "action=request";
+const std::string Queries::ACTION_RESETPP = "resetpp";
+const std::string Queries::ACTION_SET = "set-value";
+const std::string Queries::ACTION_SETCTRLSTATE = "action=setctrlstate";  // TODO remove
+const std::string Queries::ACTION_SET_LOCALE = "action=set-locale";
+const std::string Queries::ACTION_START = "start";
+const std::string Queries::ACTION_STOP = "stop";
+const std::string Queries::ACTION_UNLOAD_MODULE = "unloadmod";
+const std::string Queries::TASK = "task=";
+const std::string Services::CTRL = "/ctrl";
+const std::string Services::FILESERVICE = "/fileservice";
+const std::string Services::RW = "/rw";
+const std::string Services::SUBSCRIPTION = "/subscription";
+const std::string Services::USERS = "/users";
+const std::string Resources::INSTANCES = "/instances";
+const std::string Resources::JOINTTARGET = "/jointtarget";
+const std::string Resources::LOGOUT = "/logout";
+const std::string Resources::ROBTARGET = "/robtarget";
+const std::string Resources::RW_CFG = Services::RW + "/cfg";
+const std::string Resources::RW_IOSYSTEM_SIGNALS = Services::RW + "/iosystem/signals";
+const std::string Resources::RW_MOTIONSYSTEM_MECHUNITS = Services::RW + "/motionsystem/mechunits";
+const std::string Resources::RW_PANEL_CTRLSTATE = Services::RW + "/panel/ctrl-state";
+const std::string Resources::RW_PANEL_OPMODE = Services::RW + "/panel/opmode";
+const std::string Resources::RW_RAPID_EXECUTION = Services::RW + "/rapid/execution";
+const std::string Resources::RW_RAPID_MODULES = Services::RW + "/rapid/modules";
+const std::string Resources::RW_RAPID_SYMBOL_DATA_RAPID = Services::RW + "/rapid/symbol/RAPID";
+const std::string Resources::RW_RAPID_SYMBOL_PROPERTIES_RAPID =
+    Services::RW + "/rapid/symbol/RAPID";  // TODO merge with symbol data
+const std::string Resources::RW_RAPID_TASKS = Services::RW + "/rapid/tasks";
+const std::string Resources::RW_SYSTEM = Services::RW + "/system";
 
-  const XMLAttribute XMLAttributes::CLASS_ACTIVE(Identifiers::CLASS            , Identifiers::ACTIVE);
-  const XMLAttribute XMLAttributes::CLASS_CFG_DT_INSTANCE_LI(Identifiers::CLASS, Identifiers::CFG_DT_INSTANCE_LI);
-  const XMLAttribute XMLAttributes::CLASS_CFG_IA_T_LI(Identifiers::CLASS       , Identifiers::CFG_IA_T_LI);
-  const XMLAttribute XMLAttributes::CLASS_CTRL_TYPE(Identifiers::CLASS         , Identifiers::CTRL_TYPE);
-  const XMLAttribute XMLAttributes::CLASS_CTRLEXECSTATE(Identifiers::CLASS     , Identifiers::CTRLEXECSTATE);
-  const XMLAttribute XMLAttributes::CLASS_CTRLSTATE(Identifiers::CLASS         , Identifiers::CTRLSTATE);
-  const XMLAttribute XMLAttributes::CLASS_DATTYP(Identifiers::CLASS            , Identifiers::DATTYP);
-  const XMLAttribute XMLAttributes::CLASS_EXCSTATE(Identifiers::CLASS          , Identifiers::EXCSTATE);
-  const XMLAttribute XMLAttributes::CLASS_IOS_SIGNAL(Identifiers::CLASS        , Identifiers::IOS_SIGNAL);
-  const XMLAttribute XMLAttributes::CLASS_LVALUE(Identifiers::CLASS            , Identifiers::LVALUE);
-  const XMLAttribute XMLAttributes::CLASS_MOTIONTASK(Identifiers::CLASS        , Identifiers::MOTIONTASK);
-  const XMLAttribute XMLAttributes::CLASS_NAME(Identifiers::CLASS              , Identifiers::NAME);
-  const XMLAttribute XMLAttributes::CLASS_OPMODE(Identifiers::CLASS            , Identifiers::OPMODE);
-  const XMLAttribute XMLAttributes::CLASS_RAP_MODULE_INFO_LI(Identifiers::CLASS, Identifiers::RAP_MODULE_INFO_LI);
-  const XMLAttribute XMLAttributes::CLASS_RAP_TASK_LI(Identifiers::CLASS       , Identifiers::RAP_TASK_LI);
-  const XMLAttribute XMLAttributes::CLASS_RW_VERSION_NAME(Identifiers::CLASS   , Identifiers::RW_VERSION_NAME);
-  const XMLAttribute XMLAttributes::CLASS_STATE(Identifiers::CLASS             , Identifiers::STATE);
-  const XMLAttribute XMLAttributes::CLASS_SYS_OPTION_LI(Identifiers::CLASS     , Identifiers::SYS_OPTION_LI);
-  const XMLAttribute XMLAttributes::CLASS_SYS_SYSTEM_LI(Identifiers::CLASS     , Identifiers::SYS_SYSTEM_LI);
-  const XMLAttribute XMLAttributes::CLASS_TYPE(Identifiers::CLASS              , Identifiers::TYPE);
-  const XMLAttribute XMLAttributes::CLASS_VALUE(Identifiers::CLASS             , Identifiers::VALUE);
-  const XMLAttribute XMLAttributes::CLASS_OPTION(Identifiers::CLASS            , Identifiers::OPTION);
+const XMLAttribute XMLAttributes::CLASS_ACTIVE(Identifiers::CLASS, Identifiers::ACTIVE);
+const XMLAttribute XMLAttributes::CLASS_CFG_DT_INSTANCE_LI(Identifiers::CLASS, Identifiers::CFG_DT_INSTANCE_LI);
+const XMLAttribute XMLAttributes::CLASS_CFG_IA_T_LI(Identifiers::CLASS, Identifiers::CFG_IA_T_LI);
+const XMLAttribute XMLAttributes::CLASS_CTRL_TYPE(Identifiers::CLASS, Identifiers::CTRL_TYPE);
+const XMLAttribute XMLAttributes::CLASS_CTRLEXECSTATE(Identifiers::CLASS, Identifiers::CTRLEXECSTATE);
+const XMLAttribute XMLAttributes::CLASS_CTRLSTATE(Identifiers::CLASS, Identifiers::CTRLSTATE);
+const XMLAttribute XMLAttributes::CLASS_DATTYP(Identifiers::CLASS, Identifiers::DATTYP);
+const XMLAttribute XMLAttributes::CLASS_EXCSTATE(Identifiers::CLASS, Identifiers::EXCSTATE);
+const XMLAttribute XMLAttributes::CLASS_IOS_SIGNAL(Identifiers::CLASS, Identifiers::IOS_SIGNAL);
+const XMLAttribute XMLAttributes::CLASS_LVALUE(Identifiers::CLASS, Identifiers::LVALUE);
+const XMLAttribute XMLAttributes::CLASS_MOTIONTASK(Identifiers::CLASS, Identifiers::MOTIONTASK);
+const XMLAttribute XMLAttributes::CLASS_NAME(Identifiers::CLASS, Identifiers::NAME);
+const XMLAttribute XMLAttributes::CLASS_OPMODE(Identifiers::CLASS, Identifiers::OPMODE);
+const XMLAttribute XMLAttributes::CLASS_RAP_MODULE_INFO_LI(Identifiers::CLASS, Identifiers::RAP_MODULE_INFO_LI);
+const XMLAttribute XMLAttributes::CLASS_RAP_TASK_LI(Identifiers::CLASS, Identifiers::RAP_TASK_LI);
+const XMLAttribute XMLAttributes::CLASS_RW_VERSION_NAME(Identifiers::CLASS, Identifiers::RW_VERSION_NAME);
+const XMLAttribute XMLAttributes::CLASS_STATE(Identifiers::CLASS, Identifiers::STATE);
+const XMLAttribute XMLAttributes::CLASS_SYS_OPTION_LI(Identifiers::CLASS, Identifiers::SYS_OPTION_LI);
+const XMLAttribute XMLAttributes::CLASS_SYS_SYSTEM_LI(Identifiers::CLASS, Identifiers::SYS_SYSTEM_LI);
+const XMLAttribute XMLAttributes::CLASS_TYPE(Identifiers::CLASS, Identifiers::TYPE);
+const XMLAttribute XMLAttributes::CLASS_VALUE(Identifiers::CLASS, Identifiers::VALUE);
+const XMLAttribute XMLAttributes::CLASS_OPTION(Identifiers::CLASS, Identifiers::OPTION);
 
-  std::ostream& operator<<(std::ostream& os, MastershipDomain domain)
+std::ostream& operator<<(std::ostream& os, MastershipDomain domain)
+{
+  switch (domain)
   {
-    switch (domain)
-    {
-      case MastershipDomain::edit:
-        os << "edit";
-        break;
-      case MastershipDomain::motion:
-        os << "motion";
-        break;
-      default:
-        BOOST_THROW_EXCEPTION(std::logic_error {"Invalid v2_0::MastershipDomain value"});
-    }
-
-    return os;
+    case MastershipDomain::edit:
+      os << "edit";
+      break;
+    case MastershipDomain::motion:
+      os << "motion";
+      break;
+    default:
+      BOOST_THROW_EXCEPTION(std::logic_error{ "Invalid v2_0::MastershipDomain value" });
   }
 
-
-  std::ostream& operator<<(std::ostream& os, Mastership mastership)
-  {
-    switch (mastership)
-    {
-      case Mastership::Implicit:
-        os << "implicit";
-        break;
-      case Mastership::Explicit:
-        os << "explicit";
-        break;
-      default:
-        BOOST_THROW_EXCEPTION(std::logic_error {"Invalid v2_0::Mastership value"});
-    }
-
-    return os;
-  }
+  return os;
 }
+
+std::ostream& operator<<(std::ostream& os, Mastership mastership)
+{
+  switch (mastership)
+  {
+    case Mastership::Implicit:
+      os << "implicit";
+      break;
+    case Mastership::Explicit:
+      os << "explicit";
+      break;
+    default:
+      BOOST_THROW_EXCEPTION(std::logic_error{ "Invalid v2_0::Mastership value" });
+  }
+
+  return os;
+}
+}  // namespace abb::rws::v2_0

--- a/src/v2_0/rws_client.cpp
+++ b/src/v2_0/rws_client.cpp
@@ -46,13 +46,12 @@
 
 #include <iostream>
 
-
 namespace
 {
-static const char EXCEPTION_CREATE_STRING[]{"Failed to create string"};
+static const char EXCEPTION_CREATE_STRING[]{ "Failed to create string" };
 }
 
-namespace abb :: rws :: v2_0
+namespace abb ::rws ::v2_0
 {
 using namespace Poco::Net;
 
@@ -65,25 +64,18 @@ using namespace Poco::Net;
  */
 
 RWSClient::RWSClient(ConnectionOptions const& connection_options)
-: connectionOptions_ {connection_options}
-, context_ {
-    new Poco::Net::Context {
-      Poco::Net::Context::CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE, 9, false, "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH"
-    }
-  }
-, session_ {connectionOptions_.ip_address, connectionOptions_.port, context_}
-, http_client_ {session_, connectionOptions_.username, connectionOptions_.password}
+  : connectionOptions_{ connection_options }
+  , context_{ new Poco::Net::Context{ Poco::Net::Context::CLIENT_USE, "", "", "", Poco::Net::Context::VERIFY_NONE, 9,
+                                      false, "ALL:!ADH:!LOW:!EXP:!MD5:@STRENGTH" } }
+  , session_{ connectionOptions_.ip_address, connectionOptions_.port, context_ }
+  , http_client_{ session_, connectionOptions_.username, connectionOptions_.password }
 {
-  session_.setTimeout(
-    connectionOptions_.connection_timeout.count(),
-    connectionOptions_.send_timeout.count(),
-    connectionOptions_.receive_timeout.count()
-  );
+  session_.setTimeout(connectionOptions_.connection_timeout.count(), connectionOptions_.send_timeout.count(),
+                      connectionOptions_.receive_timeout.count());
 
   // Make a request to the server to check connection and initiate authentification.
   getRobotWareSystem();
 }
-
 
 RWSClient::~RWSClient()
 {
@@ -97,7 +89,6 @@ RWSClient::~RWSClient()
     std::cerr << "Exception in RWSClient::~RWSClient(): " << e.what() << std::endl;
   }
 }
-
 
 RWSClient::RWSResult RWSClient::getContollerService()
 {
@@ -113,7 +104,7 @@ RWSClient::RWSResult RWSClient::getConfigurationInstances(const std::string& top
 
 RWSClient::RWSResult RWSClient::getIOSignals()
 {
-  std::string const & uri = Resources::RW_IOSYSTEM_SIGNALS;
+  std::string const& uri = Resources::RW_IOSYSTEM_SIGNALS;
   return parseContent(httpGet(uri));
 }
 
@@ -126,7 +117,7 @@ RWSClient::RWSResult RWSClient::getIOSignal(const std::string& iosignal)
   }
   catch (boost::exception& e)
   {
-    e << IoSignalErrorInfo {iosignal};
+    e << IoSignalErrorInfo{ iosignal };
     throw;
   }
 }
@@ -149,10 +140,8 @@ RWSClient::RWSResult RWSClient::getMechanicalUnitJointTarget(const std::string& 
   return parseContent(httpGet(uri));
 }
 
-RWSClient::RWSResult RWSClient::getMechanicalUnitRobTarget(const std::string& mechunit,
-                                                           Coordinate coordinate,
-                                                           const std::string& tool,
-                                                           const std::string& wobj)
+RWSClient::RWSResult RWSClient::getMechanicalUnitRobTarget(const std::string& mechunit, Coordinate coordinate,
+                                                           const std::string& tool, const std::string& wobj)
 {
   std::string uri = generateMechanicalUnitPath(mechunit) + Resources::ROBTARGET;
 
@@ -171,20 +160,20 @@ RWSClient::RWSResult RWSClient::getMechanicalUnitRobTarget(const std::string& me
   {
     case Coordinate::BASE:
       uri += coordinate_arg + SystemConstants::General::COORDINATE_BASE + args;
-    break;
+      break;
     case Coordinate::WORLD:
       uri += coordinate_arg + SystemConstants::General::COORDINATE_WORLD + args;
-    break;
+      break;
     case Coordinate::TOOL:
       uri += coordinate_arg + SystemConstants::General::COORDINATE_TOOL + args;
-    break;
+      break;
     case Coordinate::WOBJ:
       uri += coordinate_arg + SystemConstants::General::COORDINATE_WOBJ + args;
-    break;
+      break;
     default:
       // If the "ACTIVE" enumeration is passed in (or any other non-identified value),
       // do not add any arguments to this command
-    break;
+      break;
   }
 
   return parseContent(httpGet(uri));
@@ -208,7 +197,7 @@ void RWSClient::setIOSignal(const std::string& iosignal, const std::string& valu
   }
   catch (boost::exception& e)
   {
-    e << IoSignalErrorInfo {iosignal};
+    e << IoSignalErrorInfo{ iosignal };
     throw;
   }
 }
@@ -235,35 +224,27 @@ void RWSClient::deleteFile(const FileResource& resource)
   httpDelete(uri);
 }
 
-
 void RWSClient::logout()
 {
   std::string uri = Resources::LOGOUT;
   httpGet(uri);
 }
 
-
-void RWSClient::registerLocalUser(const std::string& username,
-                                                  const std::string& application,
-                                                  const std::string& location)
+void RWSClient::registerLocalUser(const std::string& username, const std::string& application,
+                                  const std::string& location)
 {
   std::string uri = Services::USERS;
-  std::string content = "username=" + username +
-             "&application=" + application +
-             "&location=" + location +
-             "&ulocale=" + SystemConstants::General::LOCAL;
+  std::string content = "username=" + username + "&application=" + application + "&location=" + location +
+                        "&ulocale=" + SystemConstants::General::LOCAL;
 
   httpPost(uri, content);
 }
 
-void RWSClient::registerRemoteUser(const std::string& username,
-                                                   const std::string& application,
-                                                   const std::string& location)
+void RWSClient::registerRemoteUser(const std::string& username, const std::string& application,
+                                   const std::string& location)
 {
   std::string uri = Services::USERS;
-  std::string content = "username=" + username +
-                        "&application=" + application +
-                        "&location=" + location +
+  std::string content = "username=" + username + "&application=" + application + "&location=" + location +
                         "&ulocale=" + SystemConstants::General::REMOTE;
 
   httpPost(uri, content);
@@ -277,7 +258,6 @@ RWSClient::RWSResult RWSClient::parseContent(const POCOResult& poco_result)
 {
   return parser_.parseString(poco_result.content());
 }
-
 
 std::string RWSClient::generateConfigurationPath(const std::string& topic, const std::string& type)
 {
@@ -304,69 +284,53 @@ POCOResult RWSClient::httpGet(const std::string& uri)
   POCOResult const result = http_client_.httpGet(uri);
 
   if (result.httpStatus() != HTTPResponse::HTTP_NO_CONTENT && result.httpStatus() != HTTPResponse::HTTP_OK)
-    BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
-      << HttpMethodErrorInfo {"GET"}
-      << UriErrorInfo {uri}
-      << HttpStatusErrorInfo {result.httpStatus()}
-      << HttpResponseContentErrorInfo {result.content()}
-      << HttpReasonErrorInfo {result.reason()}
-    );
+    BOOST_THROW_EXCEPTION(
+        ProtocolError{ "HTTP response status not accepted" }
+        << HttpMethodErrorInfo{ "GET" } << UriErrorInfo{ uri } << HttpStatusErrorInfo{ result.httpStatus() }
+        << HttpResponseContentErrorInfo{ result.content() } << HttpReasonErrorInfo{ result.reason() });
 
   return result;
 }
-
 
 POCOResult RWSClient::httpPost(const std::string& uri, const std::string& content, const std::string& content_type)
 {
   POCOResult const result = http_client_.httpPost(uri, content, content_type);
 
   if (result.httpStatus() != HTTPResponse::HTTP_NO_CONTENT && result.httpStatus() != HTTPResponse::HTTP_OK)
-    BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
-      << HttpMethodErrorInfo {"POST"}
-      << UriErrorInfo {uri}
-      << HttpStatusErrorInfo {result.httpStatus()}
-      << HttpResponseContentErrorInfo {result.content()}
-      << HttpRequestContentErrorInfo {content}
-      << HttpReasonErrorInfo {result.reason()}
-    );
+    BOOST_THROW_EXCEPTION(ProtocolError{ "HTTP response status not accepted" }
+                          << HttpMethodErrorInfo{ "POST" } << UriErrorInfo{ uri }
+                          << HttpStatusErrorInfo{ result.httpStatus() }
+                          << HttpResponseContentErrorInfo{ result.content() } << HttpRequestContentErrorInfo{ content }
+                          << HttpReasonErrorInfo{ result.reason() });
 
   return result;
 }
-
 
 POCOResult RWSClient::httpPut(const std::string& uri, const std::string& content, const std::string& content_type)
 {
   POCOResult const result = http_client_.httpPut(uri, content, content_type);
 
   if (result.httpStatus() != HTTPResponse::HTTP_OK && result.httpStatus() != HTTPResponse::HTTP_CREATED)
-    BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
-      << HttpMethodErrorInfo {"PUT"}
-      << UriErrorInfo {uri}
-      << HttpStatusErrorInfo {result.httpStatus()}
-      << HttpResponseContentErrorInfo {result.content()}
-      << HttpRequestContentErrorInfo {content}
-      << HttpReasonErrorInfo {result.reason()}
-    );
+    BOOST_THROW_EXCEPTION(ProtocolError{ "HTTP response status not accepted" }
+                          << HttpMethodErrorInfo{ "PUT" } << UriErrorInfo{ uri }
+                          << HttpStatusErrorInfo{ result.httpStatus() }
+                          << HttpResponseContentErrorInfo{ result.content() } << HttpRequestContentErrorInfo{ content }
+                          << HttpReasonErrorInfo{ result.reason() });
 
   return result;
 }
-
 
 POCOResult RWSClient::httpDelete(const std::string& uri)
 {
   POCOResult const result = http_client_.httpDelete(uri);
   if (result.httpStatus() != HTTPResponse::HTTP_OK && result.httpStatus() != HTTPResponse::HTTP_NO_CONTENT)
-    BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
-      << HttpMethodErrorInfo {"DELETE"}
-      << HttpStatusErrorInfo {result.httpStatus()}
-      << HttpResponseContentErrorInfo {result.content()}
-      << UriErrorInfo {uri}
-      << HttpReasonErrorInfo {result.reason()}
-    );
+    BOOST_THROW_EXCEPTION(ProtocolError{ "HTTP response status not accepted" }
+                          << HttpMethodErrorInfo{ "DELETE" } << HttpStatusErrorInfo{ result.httpStatus() }
+                          << HttpResponseContentErrorInfo{ result.content() } << UriErrorInfo{ uri }
+                          << HttpReasonErrorInfo{ result.reason() });
 
   return result;
 }
-
 
 std::string RWSClient::openSubscription(std::vector<std::pair<std::string, SubscriptionPriority>> const& resources)
 {
@@ -374,37 +338,29 @@ std::string RWSClient::openSubscription(std::vector<std::pair<std::string, Subsc
   std::stringstream subscription_content;
   for (std::size_t i = 0; i < resources.size(); ++i)
   {
-    subscription_content << "resources=" << i
-                          << "&"
-                          << i << "=" << resources[i].first
-                          << "&"
-                          << i << "-p=" << static_cast<int>(resources[i].second)
-                          << (i < resources.size() - 1 ? "&" : "");
+    subscription_content << "resources=" << i << "&" << i << "=" << resources[i].first << "&" << i
+                         << "-p=" << static_cast<int>(resources[i].second) << (i < resources.size() - 1 ? "&" : "");
   }
 
   std::string content_type = "application/x-www-form-urlencoded;v=2.0";
 
   // Make a subscription request.
-  POCOResult const poco_result = http_client_.httpPost(Services::SUBSCRIPTION, subscription_content.str(), content_type);
+  POCOResult const poco_result =
+      http_client_.httpPost(Services::SUBSCRIPTION, subscription_content.str(), content_type);
 
   if (poco_result.httpStatus() != HTTPResponse::HTTP_CREATED)
     BOOST_THROW_EXCEPTION(
-      ProtocolError {"Unable to create Subscription"}
-      << HttpStatusErrorInfo {poco_result.httpStatus()}
-      << HttpReasonErrorInfo {poco_result.reason()}
-      << HttpMethodErrorInfo {HTTPRequest::HTTP_POST}
-      << HttpRequestContentErrorInfo {subscription_content.str()}
-      << HttpResponseContentErrorInfo {poco_result.content()}
-      << HttpResponseErrorInfo {poco_result}
-      << UriErrorInfo {Services::SUBSCRIPTION}
-    );
+        ProtocolError{ "Unable to create Subscription" }
+        << HttpStatusErrorInfo{ poco_result.httpStatus() } << HttpReasonErrorInfo{ poco_result.reason() }
+        << HttpMethodErrorInfo{ HTTPRequest::HTTP_POST } << HttpRequestContentErrorInfo{ subscription_content.str() }
+        << HttpResponseContentErrorInfo{ poco_result.content() } << HttpResponseErrorInfo{ poco_result }
+        << UriErrorInfo{ Services::SUBSCRIPTION });
 
   std::string subscription_group_id;
 
   // Find "Location" header attribute
-  auto const h = std::find_if(
-    poco_result.headerInfo().begin(), poco_result.headerInfo().end(),
-    [] (auto const& p) { return p.first == "Location"; });
+  auto const h = std::find_if(poco_result.headerInfo().begin(), poco_result.headerInfo().end(),
+                              [](auto const& p) { return p.first == "Location"; });
 
   if (h != poco_result.headerInfo().end())
   {
@@ -416,11 +372,10 @@ std::string RWSClient::openSubscription(std::vector<std::pair<std::string, Subsc
   }
 
   if (subscription_group_id.empty())
-    BOOST_THROW_EXCEPTION(ProtocolError {"Cannot get subscription group from HTTP response"});
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot get subscription group from HTTP response" });
 
   return subscription_group_id;
 }
-
 
 void RWSClient::closeSubscription(std::string const& subscription_group_id)
 {
@@ -429,13 +384,12 @@ void RWSClient::closeSubscription(std::string const& subscription_group_id)
   httpDelete(uri);
 }
 
-
 Poco::Net::WebSocket RWSClient::receiveSubscription(std::string const& subscription_group_id)
 {
-  return http_client_.webSocketConnect("/poll/" + subscription_group_id, "rws_subscription",
-    Poco::Net::HTTPSClientSession {connectionOptions_.ip_address, connectionOptions_.port, context_});
+  return http_client_.webSocketConnect(
+      "/poll/" + subscription_group_id, "rws_subscription",
+      Poco::Net::HTTPSClientSession{ connectionOptions_.ip_address, connectionOptions_.port, context_ });
 }
-
 
 std::string RWSClient::getResourceURI(IOSignalResource const& io_signal) const
 {
@@ -446,7 +400,6 @@ std::string RWSClient::getResourceURI(IOSignalResource const& io_signal) const
   resource_uri += Identifiers::STATE;
   return resource_uri;
 }
-
 
 std::string RWSClient::getResourceURI(RAPIDResource const& resource) const
 {
@@ -462,35 +415,31 @@ std::string RWSClient::getResourceURI(RAPIDResource const& resource) const
   return resource_uri;
 }
 
-
 std::string RWSClient::getResourceURI(ControllerStateResource const& resource) const
 {
   return "/rw/panel/ctrl-state";
 }
-
 
 std::string RWSClient::getResourceURI(RAPIDExecutionStateResource const&) const
 {
   return "/rw/rapid/execution;ctrlexecstate";
 }
 
-
 std::string RWSClient::getResourceURI(OperationModeResource const&) const
 {
   return "/rw/panel/opmode";
 }
 
-
 void RWSClient::processEvent(Poco::AutoPtr<Poco::XML::Document> doc, SubscriptionCallback& callback) const
 {
   // IMPORTANT: don't use AutoPtr<XML::Node> here! Otherwise you will get memory corruption.
-  Poco::XML::Node const * li_node = doc->getNodeByPath("html/body/div/ul/li");
+  Poco::XML::Node const* li_node = doc->getNodeByPath("html/body/div/ul/li");
   if (!li_node)
-    BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: can't find XML path html/body/div/ul/li"});
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS event message: can't find XML path html/body/div/ul/li" });
 
-  auto const * a_node = li_node->getNodeByPath("a");
+  auto const* a_node = li_node->getNodeByPath("a");
   if (!a_node)
-    BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: can't find XML path html/body/div/ul/li/a"});
+    BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS event message: can't find XML path html/body/div/ul/li/a" });
 
   std::string uri;
   uri = xmlNodeGetAttributeValue(a_node, "href");
@@ -503,22 +452,24 @@ void RWSClient::processEvent(Poco::AutoPtr<Poco::XML::Document> doc, Subscriptio
     std::string const prefix = "/rw/iosystem/signals/";
 
     if (uri.find(prefix) != 0)
-      BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: invalid resource URI"} << UriErrorInfo {uri});
+      BOOST_THROW_EXCEPTION(ProtocolError{ "Cannot parse RWS event message: invalid resource URI" }
+                            << UriErrorInfo{ uri });
 
     event.signal = uri.substr(prefix.length(), uri.find(";") - prefix.length());
-    event.value = xmlFindTextContent(li_node, XMLAttribute {"class", "lvalue"});
+    event.value = xmlFindTextContent(li_node, XMLAttribute{ "class", "lvalue" });
     callback.processEvent(event);
   }
   else if (class_attribute_value == "rap-ctrlexecstate-ev")
   {
     RAPIDExecutionStateEvent event;
 
-    std::string const state_string = xmlFindTextContent(li_node, XMLAttribute {"class", "ctrlexecstate"});
+    std::string const state_string = xmlFindTextContent(li_node, XMLAttribute{ "class", "ctrlexecstate" });
     event.state = rw::makeRAPIDExecutionState(state_string);
 
     callback.processEvent(event);
   }
   else
-    BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: unrecognized class " + class_attribute_value});
+    BOOST_THROW_EXCEPTION(
+        ProtocolError{ "Cannot parse RWS event message: unrecognized class " + class_attribute_value });
 }
-}
+}  // namespace abb::rws::v2_0

--- a/src/v2_0/rws_interface.cpp
+++ b/src/v2_0/rws_interface.cpp
@@ -44,19 +44,16 @@
 #include <iomanip>
 #include <stdexcept>
 
-
 namespace
 {
-static const char EXCEPTION_GET_CFG[]{"Failed to get configuration instances"};
-static const char EXCEPTION_PARSE_CFG[]{"Failed to parse configuration instances"};
-}
+static const char EXCEPTION_GET_CFG[]{ "Failed to get configuration instances" };
+static const char EXCEPTION_PARSE_CFG[]{ "Failed to parse configuration instances" };
+}  // namespace
 
-namespace abb :: rws :: v2_0
+namespace abb ::rws ::v2_0
 {
-
 typedef SystemConstants::ContollerStates ContollerStates;
 typedef SystemConstants::RAPID RAPID;
-
 
 static bool digitalSignalToBool(std::string const& value)
 {
@@ -66,16 +63,14 @@ static bool digitalSignalToBool(std::string const& value)
   return value == SystemConstants::IOSignals::HIGH;
 }
 
-
 /***********************************************************************************************************************
  * Class definitions: RWSInterface
  */
 
- /************************************************************
+/************************************************************
  * Primary methods
  */
-RWSInterface::RWSInterface(RWSClient& client)
-: rws_client_ {client}
+RWSInterface::RWSInterface(RWSClient& client) : rws_client_{ client }
 {
 }
 
@@ -88,31 +83,34 @@ std::vector<cfg::moc::Arm> RWSInterface::getCFGArms()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::Arm arm;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
       {
         arm.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(arm.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (arm.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "lower_joint_bound"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "lower_joint_bound"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> arm.lower_joint_bound;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "upper_joint_bound"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "upper_joint_bound"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> arm.upper_joint_bound;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
     }
 
@@ -131,41 +129,46 @@ std::vector<cfg::moc::Joint> RWSInterface::getCFGJoints()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::Joint joint;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
       {
         joint.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(joint.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (joint.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "logical_axis"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "logical_axis"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> joint.logical_axis;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "kinematic_axis_number"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "kinematic_axis_number"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> joint.kinematic_axis_number;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_arm"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_arm"))
       {
         joint.use_arm = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(joint.use_arm.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (joint.use_arm.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_transmission"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_transmission"))
       {
         joint.use_transmission = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(joint.use_transmission.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (joint.use_transmission.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
     }
 
@@ -184,31 +187,32 @@ std::vector<cfg::moc::MechanicalUnit> RWSInterface::getCFGMechanicalUnits()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::MechanicalUnit mechanical_unit;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
       {
         mechanical_unit.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(mechanical_unit.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (mechanical_unit.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_robot"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_robot"))
       {
         // Note: The 'use_robot' attribute can be empty, since not all units have a robot (i.e. skip validation).
         mechanical_unit.use_robot = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_0") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_1") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_2") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_3") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_4") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_5"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_0") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_1") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_2") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_3") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_4") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_5"))
       {
         // Note: The 'use_single_N' attribute can be empty, since not all units have singles (i.e. skip validation).
         mechanical_unit.use_singles.push_back(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
@@ -230,31 +234,32 @@ std::vector<cfg::sys::MechanicalUnitGroup> RWSInterface::getCFGMechanicalUnitGro
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::sys::MechanicalUnitGroup mechanical_unit_group;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "Name"))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "Name"))
       {
         mechanical_unit_group.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(mechanical_unit_group.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (mechanical_unit_group.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "Robot"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "Robot"))
       {
         // Note: The 'Robot' attribute can be empty, since not all groups have a robot (i.e. skip validation).
         mechanical_unit_group.robot = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_1") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_2") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_3") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_4") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_5") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_6"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_1") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_2") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_3") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_4") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_5") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "MechanicalUnit_6"))
       {
         // Note: The 'MechanicalUnit_N' attribute can be empty, since not all groups have units (i.e. skip validation).
         mechanical_unit_group.mechanical_units.push_back(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
@@ -276,24 +281,26 @@ std::vector<cfg::sys::PresentOption> RWSInterface::getCFGPresentOptions()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::sys::PresentOption present_option;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "name"))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "name"))
       {
         present_option.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(present_option.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (present_option.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "desc"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "desc"))
       {
         present_option.description = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(present_option.description.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (present_option.description.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
     }
 
@@ -312,81 +319,90 @@ std::vector<cfg::moc::Robot> RWSInterface::getCFGRobots()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::Robot robot;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
       {
         robot.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(robot.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (robot.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_robot_type"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_robot_type"))
       {
         robot.use_robot_type = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(robot.use_robot_type.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (robot.use_robot_type.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_0") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_1") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_2") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_3") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_4") ||
-              xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_5"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_0") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_1") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_2") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_3") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_4") ||
+               xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint_5"))
       {
         // Note: The 'use_joint_N' attribute can be empty, since not all robots have 6 joints (i.e. skip validation).
         robot.use_joints.push_back(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_x"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_x"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.pos.x.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         robot.base_frame.pos.x.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_y"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_y"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.pos.y.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         robot.base_frame.pos.y.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_z"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_z"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.pos.z.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         robot.base_frame.pos.z.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u0"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u0"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.rot.q1.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u1"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u1"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.rot.q2.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u2"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u2"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.rot.q3.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u3"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u3"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> robot.base_frame.rot.q4.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_coordinated"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_coordinated"))
       {
         // Note: The 'base_frame_coordinated' attribute can be empty (i.e. skip validation).
         //       It is only used if this robot's base frame is moved by another robot or single.
@@ -394,7 +410,7 @@ std::vector<cfg::moc::Robot> RWSInterface::getCFGRobots()
       }
     }
 
-     result.push_back(robot);
+    result.push_back(robot);
   }
 
   return result;
@@ -409,76 +425,86 @@ std::vector<cfg::moc::Single> RWSInterface::getCFGSingles()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::Single single;
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, Identifiers::NAME))
       {
         single.name = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(single.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (single.name.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_type"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_single_type"))
       {
         single.use_single_type = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(single.use_single_type.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (single.use_single_type.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "use_joint"))
       {
         single.use_joint = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(single.use_joint.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (single.use_joint.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_x"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_x"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.pos.x.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         single.base_frame.pos.x.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_y"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_y"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.pos.y.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         single.base_frame.pos.y.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_z"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_pos_z"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.pos.z.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         single.base_frame.pos.z.value *= 1e3;
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u0"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u0"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.rot.q1.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u1"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u1"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.rot.q2.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u2"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u2"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.rot.q3.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u3"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_orient_u3"))
       {
         std::stringstream ss(xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE));
         ss >> single.base_frame.rot.q4.value;
-        if(ss.fail()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (ss.fail())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
       }
-      else if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_coordinated"))
+      else if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "base_frame_coordinated"))
       {
         // Note: The 'base_frame_coordinated' attribute can be empty (i.e. skip validation).
         //       It is only used if this single's base frame is moved by another robot or single.
@@ -501,22 +527,24 @@ std::vector<cfg::moc::Transmission> RWSInterface::getCFGTransmission()
   std::vector<Poco::XML::Node*> instances;
   instances = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_DT_INSTANCE_LI);
 
-  for(size_t i = 0; i < instances.size(); ++i)
+  for (size_t i = 0; i < instances.size(); ++i)
   {
     std::vector<Poco::XML::Node*> attributes = xmlFindNodes(instances[i], XMLAttributes::CLASS_CFG_IA_T_LI);
 
     cfg::moc::Transmission transmission;
 
     transmission.name = xmlNodeGetAttributeValue(instances[i], Identifiers::TITLE);
-    if(transmission.name.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+    if (transmission.name.empty())
+      throw std::runtime_error(EXCEPTION_PARSE_CFG);
 
-    for(size_t j = 0; j < attributes.size(); ++j)
+    for (size_t j = 0; j < attributes.size(); ++j)
     {
       Poco::XML::Node* attribute = attributes[j];
-      if(xmlNodeHasAttribute(attribute, Identifiers::TITLE, "rotating_move"))
+      if (xmlNodeHasAttribute(attribute, Identifiers::TITLE, "rotating_move"))
       {
         std::string temp = xmlFindTextContent(attribute, XMLAttributes::CLASS_VALUE);
-        if(temp.empty()) throw std::runtime_error(EXCEPTION_PARSE_CFG);
+        if (temp.empty())
+          throw std::runtime_error(EXCEPTION_PARSE_CFG);
         transmission.rotating_move = (temp == "true");
       }
     }
@@ -531,23 +559,21 @@ std::vector<RobotWareOptionInfo> RWSInterface::getPresentRobotWareOptions()
 {
   std::vector<RobotWareOptionInfo> result;
 
-  RWSResult rws_result = rws_client_.getConfigurationInstances(Identifiers::SYS,
-                                                                          Identifiers::PRESENT_OPTIONS);
+  RWSResult rws_result = rws_client_.getConfigurationInstances(Identifiers::SYS, Identifiers::PRESENT_OPTIONS);
 
   std::vector<Poco::XML::Node*> node_list = xmlFindNodes(rws_result, XMLAttributes::CLASS_CFG_IA_T_LI);
 
-  for (size_t i = 0; i < node_list.size(); i+=2)
+  for (size_t i = 0; i < node_list.size(); i += 2)
   {
     if (i + 1 < node_list.size())
     {
       result.push_back(RobotWareOptionInfo(xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_VALUE),
-                                           xmlFindTextContent(node_list.at(i+1), XMLAttributes::CLASS_VALUE)));
+                                           xmlFindTextContent(node_list.at(i + 1), XMLAttributes::CLASS_VALUE)));
     }
   }
 
   return result;
 }
-
 
 std::string RWSInterface::getIOSignal(const std::string& iosignal)
 {
@@ -555,35 +581,32 @@ std::string RWSInterface::getIOSignal(const std::string& iosignal)
   return xmlFindTextContent(rws_result, XMLAttributes::CLASS_LVALUE);
 }
 
-
 MechanicalUnitStaticInfo RWSInterface::getMechanicalUnitStaticInfo(const std::string& mechunit)
 {
   RWSResult rws_result = rws_client_.getMechanicalUnitStaticInfo(mechunit);
 
   MechanicalUnitStaticInfo static_info;
   static_info.task_name = xmlFindTextContent(rws_result, XMLAttribute("class", "task-name"));
-  static_info.is_integrated_unit = xmlFindTextContent(rws_result,
-                                                      XMLAttribute("class", "is-integrated-unit"));
-  static_info.has_integrated_unit = xmlFindTextContent(rws_result,
-                                                        XMLAttribute("class", "has-integrated-unit"));
+  static_info.is_integrated_unit = xmlFindTextContent(rws_result, XMLAttribute("class", "is-integrated-unit"));
+  static_info.has_integrated_unit = xmlFindTextContent(rws_result, XMLAttribute("class", "has-integrated-unit"));
   std::string type = xmlFindTextContent(rws_result, XMLAttribute("class", "type"));
 
   // Assume mechanical unit type is undefined, update based on contents of 'type'.
   static_info.type = MechanicalUnitType::UNDEFINED;
 
-  if(type == "None")
+  if (type == "None")
   {
     static_info.type = MechanicalUnitType::NONE;
   }
-  else if(type == "TCPRobot")
+  else if (type == "TCPRobot")
   {
     static_info.type = MechanicalUnitType::TCP_ROBOT;
   }
-  else if(type == "Robot")
+  else if (type == "Robot")
   {
     static_info.type = MechanicalUnitType::ROBOT;
   }
-  else if(type == "Single")
+  else if (type == "Single")
   {
     static_info.type = MechanicalUnitType::SINGLE;
   }
@@ -595,11 +618,9 @@ MechanicalUnitStaticInfo RWSInterface::getMechanicalUnitStaticInfo(const std::st
   axes_total >> static_info.axes_total;
 
   // Basic verification.
-  if(static_info.task_name.empty() ||
-      static_info.is_integrated_unit.empty() ||
-      static_info.has_integrated_unit.empty() ||
-      static_info.type == MechanicalUnitType::UNDEFINED ||
-      axes.fail() || axes_total.fail())
+  if (static_info.task_name.empty() || static_info.is_integrated_unit.empty() ||
+      static_info.has_integrated_unit.empty() || static_info.type == MechanicalUnitType::UNDEFINED || axes.fail() ||
+      axes_total.fail())
   {
     throw std::logic_error("RWSInterface::getMechanicalUnitStaticInfo(): inconsistent data");
   }
@@ -616,10 +637,8 @@ MechanicalUnitDynamicInfo RWSInterface::getMechanicalUnitDynamicInfo(const std::
   MechanicalUnitDynamicInfo dynamic_info;
   dynamic_info.tool_name = xmlFindTextContent(rws_result, XMLAttribute("class", "tool-name"));
   dynamic_info.wobj_name = xmlFindTextContent(rws_result, XMLAttribute("class", "wobj-name"));
-  dynamic_info.payload_name = xmlFindTextContent(rws_result,
-                                                  XMLAttribute("class", "payload-name"));
-  dynamic_info.total_payload_name = xmlFindTextContent(rws_result,
-                                                        XMLAttribute("class", "total-payload-name"));
+  dynamic_info.payload_name = xmlFindTextContent(rws_result, XMLAttribute("class", "payload-name"));
+  dynamic_info.total_payload_name = xmlFindTextContent(rws_result, XMLAttribute("class", "total-payload-name"));
   dynamic_info.status = xmlFindTextContent(rws_result, XMLAttribute("class", "status"));
   dynamic_info.jog_mode = xmlFindTextContent(rws_result, XMLAttribute("class", "jog-mode"));
   std::string mode = xmlFindTextContent(rws_result, XMLAttribute("class", "mode"));
@@ -628,11 +647,11 @@ MechanicalUnitDynamicInfo RWSInterface::getMechanicalUnitDynamicInfo(const std::
   // Assume mechanical unit mode is unknown, update based on contents of 'mode'.
   dynamic_info.mode = MechanicalUnitMode::UNKNOWN_MODE;
 
-  if(mode == "Activated")
+  if (mode == "Activated")
   {
     dynamic_info.mode = MechanicalUnitMode::ACTIVATED;
   }
-  else if(mode == "Deactivated")
+  else if (mode == "Deactivated")
   {
     dynamic_info.mode = MechanicalUnitMode::DEACTIVATED;
   }
@@ -640,26 +659,22 @@ MechanicalUnitDynamicInfo RWSInterface::getMechanicalUnitDynamicInfo(const std::
   // Assume mechanical unit coordinate system is world, update based on contents of 'coord_system'.
   dynamic_info.coord_system = Coordinate::WORLD;
 
-  if(coord_system == "Base")
+  if (coord_system == "Base")
   {
     dynamic_info.coord_system = Coordinate::BASE;
   }
-  else if(coord_system == "Tool")
+  else if (coord_system == "Tool")
   {
     dynamic_info.coord_system = Coordinate::TOOL;
   }
-  else if(coord_system == "Wobj")
+  else if (coord_system == "Wobj")
   {
     dynamic_info.coord_system = Coordinate::WOBJ;
   }
 
   // Basic verification.
-  if(dynamic_info.tool_name.empty() ||
-      dynamic_info.wobj_name.empty() ||
-      dynamic_info.payload_name.empty() ||
-      dynamic_info.total_payload_name.empty() ||
-      dynamic_info.status.empty() ||
-      dynamic_info.jog_mode.empty() ||
+  if (dynamic_info.tool_name.empty() || dynamic_info.wobj_name.empty() || dynamic_info.payload_name.empty() ||
+      dynamic_info.total_payload_name.empty() || dynamic_info.status.empty() || dynamic_info.jog_mode.empty() ||
       dynamic_info.mode == MechanicalUnitMode::UNKNOWN_MODE)
   {
     throw std::logic_error("RWSInterface::getMechanicalUnitDynamicInfo: inconsistent data");
@@ -673,19 +688,18 @@ JointTarget RWSInterface::getMechanicalUnitJointTarget(const std::string& mechun
   RWSResult rws_result = rws_client_.getMechanicalUnitJointTarget(mechunit);
   std::stringstream ss;
 
-  ss << "[["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_1")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_2")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_3")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_4")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_5")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_6")) << "], ["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_a")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_b")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_c")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_d")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_e")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_f")) << "]]";
+  ss << "[[" << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_1")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_2")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_3")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_4")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_5")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "rax_6")) << "], ["
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_a")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_b")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_c")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_d")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_e")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_f")) << "]]";
 
   JointTarget jointtarget;
   jointtarget.parseString(ss.str());
@@ -693,33 +707,30 @@ JointTarget RWSInterface::getMechanicalUnitJointTarget(const std::string& mechun
   return jointtarget;
 }
 
-RobTarget RWSInterface::getMechanicalUnitRobTarget(const std::string& mechunit,
-                                              Coordinate coordinate,
-                                              const std::string& tool,
-                                              const std::string& wobj)
+RobTarget RWSInterface::getMechanicalUnitRobTarget(const std::string& mechunit, Coordinate coordinate,
+                                                   const std::string& tool, const std::string& wobj)
 {
   RWSResult rws_result = rws_client_.getMechanicalUnitRobTarget(mechunit, coordinate, tool, wobj);
 
   std::stringstream ss;
 
-  ss << "[["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "x")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "y")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "z")) << "], ["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "q1")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "q2")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "q3")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "q4")) << "], ["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "cf1")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "cf4")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "cf6")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "cfx")) << "], ["
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_a")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_b")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_c")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_d")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_e")) << ","
-      << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_f")) << "]]";
+  ss << "[[" << xmlFindTextContent(rws_result, XMLAttribute("class", "x")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "y")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "z")) << "], ["
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "q1")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "q2")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "q3")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "q4")) << "], ["
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "cf1")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "cf4")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "cf6")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "cfx")) << "], ["
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_a")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_b")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_c")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_d")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_e")) << ","
+     << xmlFindTextContent(rws_result, XMLAttribute("class", "eax_f")) << "]]";
 
   RobTarget robtarget;
   robtarget.parseString(ss.str());
@@ -746,8 +757,7 @@ SystemInfo RWSInterface::getSystemInfo()
     result.system_options.push_back(xmlFindTextContent(node_list.at(i), XMLAttributes::CLASS_OPTION));
   }
 
-  result.system_type = xmlFindTextContent(rws_client_.getContollerService(),
-                                          XMLAttributes::CLASS_CTRL_TYPE);
+  result.system_type = xmlFindTextContent(rws_client_.getContollerService(), XMLAttributes::CLASS_CTRL_TYPE);
 
   return result;
 }
@@ -772,31 +782,27 @@ void RWSInterface::deleteFile(const FileResource& resource)
   rws_client_.deleteFile(resource);
 }
 
-SubscriptionGroup RWSInterface::openSubscription (const SubscriptionResources& resources)
+SubscriptionGroup RWSInterface::openSubscription(const SubscriptionResources& resources)
 {
-  return SubscriptionGroup {rws_client_, resources};
+  return SubscriptionGroup{ rws_client_, resources };
 }
 
-void RWSInterface::registerLocalUser(const std::string& username,
-                                     const std::string& application,
+void RWSInterface::registerLocalUser(const std::string& username, const std::string& application,
                                      const std::string& location)
 {
   rws_client_.registerLocalUser(username, application, location);
 }
 
-void RWSInterface::registerRemoteUser(const std::string& username,
-                                      const std::string& application,
+void RWSInterface::registerRemoteUser(const std::string& username, const std::string& application,
                                       const std::string& location)
 {
   rws_client_.registerRemoteUser(username, application, location);
 }
 
-
 void RWSInterface::setDigitalSignal(std::string const& signal_name, bool value)
 {
   setIOSignal(signal_name, value ? SystemConstants::IOSignals::HIGH : SystemConstants::IOSignals::LOW);
 }
-
 
 void RWSInterface::setAnalogSignal(std::string const& signal_name, float value)
 {
@@ -805,41 +811,36 @@ void RWSInterface::setAnalogSignal(std::string const& signal_name, float value)
   setIOSignal(signal_name, str.str());
 }
 
-
 void RWSInterface::setGroupSignal(std::string const& signal_name, std::uint32_t value)
 {
   setIOSignal(signal_name, std::to_string(value));
 }
-
 
 bool RWSInterface::getDigitalSignal(std::string const& signal_name)
 {
   return digitalSignalToBool(getIOSignal(signal_name));
 }
 
-
 float RWSInterface::getAnalogSignal(std::string const& signal_name)
 {
   return std::stof(getIOSignal(signal_name));
 }
-
 
 std::uint32_t RWSInterface::getGroupSignal(std::string const& signal_name)
 {
   return std::stoul(getIOSignal(signal_name));
 }
 
-
 rw::io::IOSignalInfo RWSInterface::getIOSignals()
 {
   auto const doc = rws_client_.getIOSignals();
   rw::io::IOSignalInfo signals;
 
-  for (auto&& node : xmlFindNodes(doc, {"class", "ios-signal-li"}))
+  for (auto&& node : xmlFindNodes(doc, { "class", "ios-signal-li" }))
   {
-    std::string const name = xmlFindTextContent(node, {"class", "name"});
-    std::string const value = xmlFindTextContent(node, {"class", "lvalue"});
-    std::string const type = xmlFindTextContent(node, {"class", "type"});
+    std::string const name = xmlFindTextContent(node, { "class", "name" });
+    std::string const value = xmlFindTextContent(node, { "class", "lvalue" });
+    std::string const type = xmlFindTextContent(node, { "class", "type" });
 
     if (!name.empty() && !value.empty())
     {
@@ -853,14 +854,12 @@ rw::io::IOSignalInfo RWSInterface::getIOSignals()
   return signals;
 }
 
-
 void RWSInterface::requestMastership(MastershipDomain domain)
 {
   std::stringstream uri;
   uri << "/rw/mastership/" << domain << "/request";
   rws_client_.httpPost(uri.str(), "", "application/x-www-form-urlencoded;v=2.0");
 }
-
 
 void RWSInterface::releaseMastership(MastershipDomain domain)
 {
@@ -869,16 +868,14 @@ void RWSInterface::releaseMastership(MastershipDomain domain)
   rws_client_.httpPost(uri.str(), "", "application/x-www-form-urlencoded;v=2.0");
 }
 
-
 /************************************************************
  * Auxiliary methods
  */
 
-bool RWSInterface::compareSingleContent(const RWSResult& rws_result,
-                                           const XMLAttribute& attribute,
-                                           const std::string& compare_string)
+bool RWSInterface::compareSingleContent(const RWSResult& rws_result, const XMLAttribute& attribute,
+                                        const std::string& compare_string)
 {
   return xmlFindTextContent(rws_result, attribute) == compare_string;
 }
 
-}
+}  // namespace abb::rws::v2_0

--- a/test/rws_rapid_test.cpp
+++ b/test/rws_rapid_test.cpp
@@ -2,122 +2,96 @@
 
 #include "rws_rapid_test.h"
 
-namespace abb :: rws
+namespace abb ::rws
 {
-    TEST(RAPIDArrayTest, testConstructStringOneDimensionArray)
-    {
-        RAPIDArray<MockRAPIDAtomic, 3> test_array
-        {
-            MockRAPIDAtomic {"data_1"},
-            MockRAPIDAtomic {"data_2"},
-            MockRAPIDAtomic {"data_3"}
-        };
+TEST(RAPIDArrayTest, testConstructStringOneDimensionArray)
+{
+  RAPIDArray<MockRAPIDAtomic, 3> test_array{ MockRAPIDAtomic{ "data_1" }, MockRAPIDAtomic{ "data_2" },
+                                             MockRAPIDAtomic{ "data_3" } };
 
-        std::string expected_constructed_string = "[data_1,data_2,data_3]";
+  std::string expected_constructed_string = "[data_1,data_2,data_3]";
 
-        EXPECT_EQ(test_array.constructString(), expected_constructed_string);
-    }
-
-    TEST(RAPIDArrayTest, testConstructStringNestedArray)
-    {
-        RAPIDArray<RAPIDArray<MockRAPIDAtomic, 3>, 2> test_nested_array 
-        {
-            RAPIDArray<MockRAPIDAtomic, 3>
-            {
-                MockRAPIDAtomic {"data_1"},
-                MockRAPIDAtomic {"data_2"},
-                MockRAPIDAtomic {"data_3"}
-            },
-            RAPIDArray<MockRAPIDAtomic, 3>
-            {
-                MockRAPIDAtomic {"data_1"},
-                MockRAPIDAtomic {"data_2"},
-                MockRAPIDAtomic {"data_3"}
-            }
-        };
-        std::string expected_constructed_string =
-            "["
-              "[data_1,data_2,data_3],"
-              "[data_1,data_2,data_3]"
-            "]";
-
-        EXPECT_EQ(test_nested_array.constructString(), expected_constructed_string);
-    }
-
-    TEST(RAPIDArrayTest, testParseStringOneDimensionArray)
-    {
-        RAPIDArray<MockRAPIDAtomic, 4> test_simple_array;
-        const std::vector<std::string> test_data = 
-        {
-            "I", "am", "your", "father"
-        };
-
-        std::string rapid_message = "[I,am,your,father]";
-        test_simple_array.parseString(rapid_message);
-
-        for(size_t i = 0; i < 4 ; ++i) 
-        {
-            EXPECT_EQ((std::string)test_simple_array.at(i), test_data.at(i));
-        }
-        EXPECT_EQ(test_simple_array.constructString(), rapid_message);
-    }
-
-    TEST(RAPIDArrayTest, testParseStringThrowsWhenPassingBadValueString)
-    {
-        RAPIDArray<MockRAPIDAtomic, 3> test_array;
-        std::string rapid_message = "[I,am,your,father]";
-
-        EXPECT_THROW(
-            {
-                test_array.parseString(rapid_message);
-            }
-            , std::invalid_argument);
-    }
-
-    TEST(RAPIDArrayTest, testParseStringNestedArray)
-    {
-        RAPIDArray<RAPIDArray<MockRAPIDAtomic, 5>, 2> test_nested_array
-        {
-            RAPIDArray<MockRAPIDAtomic, 5>(),
-            RAPIDArray<MockRAPIDAtomic, 5>()
-        };
-
-        const std::vector<std::vector<std::string>> test_data =
-        {
-            {"No","I", "am", "your", "father"},
-            {"Sator","Apero","Tenet","Opera","Rotas"}
-        };
-        std::string rapid_message = 
-            "["
-              "[No,I,am,your,father],"
-              "[Sator,Apero,Tenet,Opera,Rotas]"
-            "]";
-
-        test_nested_array.parseString(rapid_message);
-
-        for(size_t i = 0 ; i < 2 ; ++i)
-        {
-            for(size_t j = 0 ; j < 5 ; ++j)
-            {
-                EXPECT_EQ((std::string)test_nested_array.at(i).at(j), test_data.at(i).at(j));
-            }
-        }
-
-        EXPECT_EQ(test_nested_array.constructString(), rapid_message);
-    }
-
-    TEST(RAPIDArrayTest, testGetType)
-    {
-        RAPIDArray<MockRAPIDAtomic, 1> test_array;
-        EXPECT_EQ(test_array.getType(), MockRAPIDAtomic().getType());
-
-        RAPIDArray<RAPIDArray<MockRAPIDAtomic, 1>, 1> test_nested_array;
-        EXPECT_EQ(test_nested_array.getType(), MockRAPIDAtomic().getType());
-
-    }
+  EXPECT_EQ(test_array.constructString(), expected_constructed_string);
 }
 
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+TEST(RAPIDArrayTest, testConstructStringNestedArray)
+{
+  RAPIDArray<RAPIDArray<MockRAPIDAtomic, 3>, 2> test_nested_array{
+    RAPIDArray<MockRAPIDAtomic, 3>{ MockRAPIDAtomic{ "data_1" }, MockRAPIDAtomic{ "data_2" },
+                                    MockRAPIDAtomic{ "data_3" } },
+    RAPIDArray<MockRAPIDAtomic, 3>{ MockRAPIDAtomic{ "data_1" }, MockRAPIDAtomic{ "data_2" },
+                                    MockRAPIDAtomic{ "data_3" } }
+  };
+  std::string expected_constructed_string =
+      "["
+      "[data_1,data_2,data_3],"
+      "[data_1,data_2,data_3]"
+      "]";
+
+  EXPECT_EQ(test_nested_array.constructString(), expected_constructed_string);
+}
+
+TEST(RAPIDArrayTest, testParseStringOneDimensionArray)
+{
+  RAPIDArray<MockRAPIDAtomic, 4> test_simple_array;
+  const std::vector<std::string> test_data = { "I", "am", "your", "father" };
+
+  std::string rapid_message = "[I,am,your,father]";
+  test_simple_array.parseString(rapid_message);
+
+  for (size_t i = 0; i < 4; ++i)
+  {
+    EXPECT_EQ((std::string)test_simple_array.at(i), test_data.at(i));
+  }
+  EXPECT_EQ(test_simple_array.constructString(), rapid_message);
+}
+
+TEST(RAPIDArrayTest, testParseStringThrowsWhenPassingBadValueString)
+{
+  RAPIDArray<MockRAPIDAtomic, 3> test_array;
+  std::string rapid_message = "[I,am,your,father]";
+
+  EXPECT_THROW({ test_array.parseString(rapid_message); }, std::invalid_argument);
+}
+
+TEST(RAPIDArrayTest, testParseStringNestedArray)
+{
+  RAPIDArray<RAPIDArray<MockRAPIDAtomic, 5>, 2> test_nested_array{ RAPIDArray<MockRAPIDAtomic, 5>(),
+                                                                   RAPIDArray<MockRAPIDAtomic, 5>() };
+
+  const std::vector<std::vector<std::string>> test_data = { { "No", "I", "am", "your", "father" },
+                                                            { "Sator", "Apero", "Tenet", "Opera", "Rotas" } };
+  std::string rapid_message =
+      "["
+      "[No,I,am,your,father],"
+      "[Sator,Apero,Tenet,Opera,Rotas]"
+      "]";
+
+  test_nested_array.parseString(rapid_message);
+
+  for (size_t i = 0; i < 2; ++i)
+  {
+    for (size_t j = 0; j < 5; ++j)
+    {
+      EXPECT_EQ((std::string)test_nested_array.at(i).at(j), test_data.at(i).at(j));
+    }
+  }
+
+  EXPECT_EQ(test_nested_array.constructString(), rapid_message);
+}
+
+TEST(RAPIDArrayTest, testGetType)
+{
+  RAPIDArray<MockRAPIDAtomic, 1> test_array;
+  EXPECT_EQ(test_array.getType(), MockRAPIDAtomic().getType());
+
+  RAPIDArray<RAPIDArray<MockRAPIDAtomic, 1>, 1> test_nested_array;
+  EXPECT_EQ(test_nested_array.getType(), MockRAPIDAtomic().getType());
+}
+}  // namespace abb::rws
+
+int main(int argc, char** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
 }

--- a/test/rws_rapid_test.h
+++ b/test/rws_rapid_test.h
@@ -1,26 +1,26 @@
 #include <abb_librws/rws_rapid.h>
 
-namespace abb :: rws
+namespace abb ::rws
 {
-    struct MockRAPIDAtomic
-    :   public RAPIDAtomicTemplate<std::string>
-    {
-        MockRAPIDAtomic(const std::string& value = "") 
-        :   RAPIDAtomicTemplate(value) {}
+struct MockRAPIDAtomic : public RAPIDAtomicTemplate<std::string>
+{
+  MockRAPIDAtomic(const std::string& value = "") : RAPIDAtomicTemplate(value)
+  {
+  }
 
-        std::string getType() const override
-        {
-            return "mock_string";
-        }
-        
-        void parseString(const std::string& value_string) override
-        {
-            value = value_string;
-        }
+  std::string getType() const override
+  {
+    return "mock_string";
+  }
 
-        std::string constructString() const override
-        {
-            return "" + value;
-        }
-    };
-}
+  void parseString(const std::string& value_string) override
+  {
+    value = value_string;
+  }
+
+  std::string constructString() const override
+  {
+    return "" + value;
+  }
+};
+}  // namespace abb::rws


### PR DESCRIPTION
Currently we do not apply the ROS C++ style guide as stated inthe contributing guidlines of this repository. I added a .clang-format file with the ROS C++ style guide parameters. After this I formated all source and header files according to the guide lines.