### PR TITLE
GRASP-11846 Fixes build errors after 96d0d8f

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,8 +29,6 @@ find_package(Poco 1.4.3 REQUIRED COMPONENTS Foundation Net Util XML NetSSL)
 ## Find boost exception library
 find_package(Boost REQUIRED COMPONENTS exception log log_setup)
 
-set(CMAKE_CXX_FLAGS "-DBOOST_LOG_DYN_LINK")
-
 ###########
 ## Build ##
 ###########
@@ -86,13 +84,16 @@ target_include_directories(${PROJECT_NAME} PUBLIC
   $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include>
   ${Poco_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIRS}
-  ${Boost_LOG_LIBRARY}
-  ${Boost_LOG_SETUP_LIBRARY}
 )
 
 target_link_libraries(${PROJECT_NAME}
   PUBLIC ${Poco_LIBRARIES}
+
+  PUBLIC ${Boost_LOG_LIBRARY}
+  PUBLIC ${Boost_LOG_SETUP_LIBRARY}
 )
+
+target_compile_definitions(${PROJECT_NAME} PUBLIC "BOOST_LOG_DYN_LINK")
 
 if(NOT BUILD_SHARED_LIBS)
   target_compile_definitions(${PROJECT_NAME} PUBLIC "ABB_LIBRWS_STATIC_DEFINE")

--- a/src/v2_0/rws_client.cpp
+++ b/src/v2_0/rws_client.cpp
@@ -42,6 +42,8 @@
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/DOM/NodeList.h>
 
+#include <boost/log/trivial.hpp>
+
 #include <sstream>
 #include <stdexcept>
 


### PR DESCRIPTION
This patches the build introduced with https://github.com/NoMagicAi/abb_librws/commit/96d0d8f0beaeb69e99a9bc0dba97b7acaebfd2f8

It was tested on my local machine:
![Screenshot from 2022-05-11 11-32-13](https://user-images.githubusercontent.com/3832914/167818209-f817b30c-86ab-4daf-8a17-b279f6784929.png)
