### PR TITLE
GRASP-11975 Migrate to C++ 20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required(VERSION 3.5)
-set(CMAKE_CXX_STANDARD 17)
+cmake_minimum_required(VERSION 3.12)
+set(CMAKE_CXX_STANDARD 20)
 
 # Read version from the package.xml file.
 file(READ ${CMAKE_CURRENT_SOURCE_DIR}/package.xml package_xml_str)


### PR DESCRIPTION
Migrate abb_librws to use C++ 20

Tested on my local machine:
![Screenshot from 2022-05-12 10-56-19](https://user-images.githubusercontent.com/3832914/168032736-8c4c3df6-0277-459a-8fb3-7dfaf8d8dbca.png)
![Screenshot from 2022-05-12 10-55-59](https://user-images.githubusercontent.com/3832914/168032748-f2cfb0b8-10e9-480b-9a18-b6023edcf171.png)
