### PR TITLE
[GRASP-11948] Added opmode and controller state message handling to rws2

### DIFF
--- a/src/v2_0/rws_client.cpp
+++ b/src/v2_0/rws_client.cpp
@@ -529,8 +529,21 @@ void RWSClient::processEvent(Poco::AutoPtr<Poco::XML::Document> doc, Subscriptio
 
       callback.processEvent(event);
     }
-    else
-      BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: unrecognized class " + class_attribute_value});
+    else if (class_attribute_value == "pnl-ctrlstate-ev")
+    {
+      ControllerStateEvent event;
+      event.state = rw::makeControllerState(xmlFindTextContent(li_element, XMLAttribute {"class", "ctrlstate"}));
+      callback.processEvent(event);
+    }
+    else if (class_attribute_value == "pnl-opmode-ev")
+    {
+      OperationModeEvent event;
+      event.mode = rw::makeOperationMode(xmlFindTextContent(li_element, XMLAttribute {"class", "opmode"}));
+      callback.processEvent(event);
+    }
+    else{
+        BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: unrecognized class " + class_attribute_value});
+    }
   }
 }
 }


### PR DESCRIPTION
 Ticket: [ABB driver turns motors OFF/ON upon request](https://nomagic.atlassian.net/browse/GRASP-11948)

Review: @michalvi 

During implementation found out, that in RWS2 subscription crashes upon receiving motor on notification.

This is the fix