### PR TITLE
Disable logging from RWS client (too much output)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,7 +111,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR MYPROJECT_BUILD_TESTING)
   enable_testing()
 
   find_package(GTest REQUIRED)
-  find_package(Boost REQUIRED COMPONENTS exception log log_setup)
 
   add_executable(${PROJECT_NAME}-test
       test/rws_rapid_test.cpp
@@ -121,9 +120,6 @@ if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME OR MYPROJECT_BUILD_TESTING)
       ${PROJECT_NAME}
       GTest::GTest
       GTest::Main
-
-      ${Boost_LOG_LIBRARY}
-      ${Boost_LOG_SETUP_LIBRARY}
   )
 
   gtest_discover_tests(${PROJECT_NAME}-test)

--- a/src/rws_poco_client.cpp
+++ b/src/rws_poco_client.cpp
@@ -43,8 +43,6 @@
 #include <abb_librws/rws_poco_client.h>
 #include <abb_librws/rws_error.h>
 
-#include <boost/log/trivial.hpp>
-
 
 using namespace Poco;
 using namespace Poco::Net;
@@ -120,12 +118,8 @@ POCOResult POCOClient::makeHTTPRequest(const std::string& method,
   // Attempt the communication.
   try
   {
-
-    BOOST_LOG_TRIVIAL(debug) << "Tyring to " << method << " from uri=" << uri << " request_content=" << content << "\n";
     sendAndReceive(request, response, content, response_content);
 
-    BOOST_LOG_TRIVIAL(debug) << "Got status=" << response.getStatus() << " when " << method
-                             << "ing from uri=" << uri << " response_content=" << response_content << "\n";
     // Check if the server has sent an update for the cookies.
     std::vector<HTTPCookie> temp_cookies;
     response.getCookies(temp_cookies);
@@ -152,7 +146,6 @@ POCOResult POCOClient::makeHTTPRequest(const std::string& method,
     // Check if the request was unauthorized, if so add credentials.
     if (response.getStatus() == HTTPResponse::HTTP_UNAUTHORIZED)
     {
-      BOOST_LOG_TRIVIAL(debug) << "Tyring to SECURELY " << method << " from uri=" << uri << "\n";
       authenticate(request, response, content, response_content);
     }
 
@@ -278,19 +271,11 @@ void POCOClient::authenticate(HTTPRequest& request,
   // Remove any old cookies.
   cookies_.clear();
 
-  BOOST_LOG_TRIVIAL(debug) << "Authenticating to " << request.getMethod() << " from uri=" << request.getURI() << "\n";
   // Authenticate with the provided credentials.
   http_credentials_.authenticate(request, response);
-  BOOST_LOG_TRIVIAL(debug) << "Got status=" << response.getStatus() << " when authenticating to"
-                           << request.getMethod() << " to uri=" <<  request.getURI() << "\n";
 
   // Contact the server, and extract and store the received cookies.
-
-  BOOST_LOG_TRIVIAL(debug) << "After authentication, trying to " << response.getStatus() << " when authenticating to"
-                           << request.getMethod() << " to uri=" <<  request.getURI() << "\n";
   sendAndReceive(request, response, request_content, response_content);
-  BOOST_LOG_TRIVIAL(debug) << "After authentication got status=" << response.getStatus() << " when "
-                           << request.getMethod() << "ing to uri=" <<  request.getURI() << "\n";
   std::vector<HTTPCookie> temp_cookies;
   response.getCookies(temp_cookies);
 

--- a/src/v2_0/rws_client.cpp
+++ b/src/v2_0/rws_client.cpp
@@ -99,10 +99,7 @@ RWSClient::~RWSClient()
   catch (std::exception const& e)
   {
     // Catch all exceptions in dtor.
-    std::string const ex_info = boost::diagnostic_information(e);
-
-    BOOST_LOG_TRIVIAL(error) << "Exception in RWSClient::~RWSClient(): " << ex_info;
-    std::cerr << "Exception in RWSClient::~RWSClient(): " << ex_info << std::endl;
+    std::cerr << "Exception in RWSClient::~RWSClient(): " << e.what() << std::endl;
   }
 }
 


### PR DESCRIPTION
Disabled logging in librws to get rid of excessive screen output

https://nomagic.atlassian.net/browse/RMSTRNG-867