### PR TITLE
GRASP-12481 driver needs to be restarted after exceeding joint limits rapid state inconsistent

### DIFF
--- a/include/abb_librws/v2_0/rws_client.h
+++ b/include/abb_librws/v2_0/rws_client.h
@@ -362,6 +362,9 @@ private:
    */
   static std::string generateFilePath(const FileResource& resource);
 
+  static bool shouldRetry(const POCOResult result,
+                          std::set<Poco::Net::HTTPResponse::HTTPStatus> const& retry_required_statuses);
+
   ConnectionOptions const connectionOptions_;
   Poco::Net::Context::Ptr context_;
   Poco::Net::HTTPSClientSession session_;

--- a/include/abb_librws/v2_0/rws_client.h
+++ b/include/abb_librws/v2_0/rws_client.h
@@ -362,8 +362,14 @@ private:
    */
   static std::string generateFilePath(const FileResource& resource);
 
-  static bool shouldRetry(const POCOResult result,
-                          std::set<Poco::Net::HTTPResponse::HTTPStatus> const& retry_required_statuses);
+  /**
+   * \brief Method to verify whether the Post method requires retry
+   *
+   * \param Http status code returned by client
+   *
+   * \return bool
+   */
+  static bool shouldRetryPost(Poco::Net::HTTPResponse::HTTPStatus status);
 
   ConnectionOptions const connectionOptions_;
   Poco::Net::Context::Ptr context_;

--- a/src/v2_0/rws_client.cpp
+++ b/src/v2_0/rws_client.cpp
@@ -332,13 +332,8 @@ POCOResult RWSClient::httpPost(const std::string& uri, const std::string& conten
 {
   POCOResult result = http_client_.httpPost(uri, content, content_type);
   std::list<std::chrono::milliseconds>::const_iterator it=connectionOptions_.retry_backoff.begin();
-  static std::set<Poco::Net::HTTPResponse::HTTPStatus> const retry_required_statuses {
-    HTTPResponse::HTTP_SERVICE_UNAVAILABLE, //Received when robot server is busy and not able to respond now
-    HTTPResponse::HTTP_FORBIDDEN //Received e.g. when robot is updating rapid data and the resource is held by robot
-                                 //or when rapid execution is stopping and we try to reset PP
-  };
 
-  while (shouldRetry(result, retry_required_statuses) && it != connectionOptions_.retry_backoff.end()){
+  while (shouldRetryPost(result.httpStatus()) && it != connectionOptions_.retry_backoff.end()){
     std::this_thread::sleep_for(*(it++));
     BOOST_LOG_TRIVIAL(warning) << "Received status " << result.httpStatus()
     << " for " << uri << " doing retry. Response is: " << result.content();
@@ -527,10 +522,11 @@ std::string RWSClient::getResourceURI(OperationModeResource const&) const
 }
 
 
-bool RWSClient::shouldRetry(const POCOResult result,
-                            std::set<Poco::Net::HTTPResponse::HTTPStatus> const& retry_required_statuses)
+bool RWSClient::shouldRetryPost(Poco::Net::HTTPResponse::HTTPStatus status)
 {
-  return retry_required_statuses.count(result.httpStatus());
+  return status == HTTPResponse::HTTP_SERVICE_UNAVAILABLE //Received when robot server is busy and not able to respond now
+    || status == HTTPResponse::HTTP_FORBIDDEN; //Received e.g. when robot is updating rapid data and the resource is held by robot
+                                 //or when rapid execution is stopping and we try to reset PP
 }
 
 

--- a/src/v2_0/rws_client.cpp
+++ b/src/v2_0/rws_client.cpp
@@ -332,13 +332,13 @@ POCOResult RWSClient::httpPost(const std::string& uri, const std::string& conten
 {
   POCOResult result = http_client_.httpPost(uri, content, content_type);
   std::list<std::chrono::milliseconds>::const_iterator it=connectionOptions_.retry_backoff.begin();
-  std::set<Poco::Net::HTTPResponse::HTTPStatus> retry_status {
+  static std::set<Poco::Net::HTTPResponse::HTTPStatus> const retry_required_statuses {
     HTTPResponse::HTTP_SERVICE_UNAVAILABLE, //Received when robot server is busy and not able to respond now
     HTTPResponse::HTTP_FORBIDDEN //Received e.g. when robot is updating rapid data and the resource is held by robot
                                  //or when rapid execution is stopping and we try to reset PP
   };
 
-  while ((retry_status.find(result.httpStatus()) == retry_status.end()) && it != connectionOptions_.retry_backoff.end()){
+  while (shouldRetry(result, retry_required_statuses) && it != connectionOptions_.retry_backoff.end()){
     std::this_thread::sleep_for(*(it++));
     BOOST_LOG_TRIVIAL(warning) << "Received status " << result.httpStatus()
     << " for " << uri << " doing retry. Response is: " << result.content();
@@ -357,7 +357,6 @@ POCOResult RWSClient::httpPost(const std::string& uri, const std::string& conten
 
   return result;
 }
-
 
 POCOResult RWSClient::httpPut(const std::string& uri, const std::string& content, const std::string& content_type)
 {
@@ -525,6 +524,13 @@ std::string RWSClient::getResourceURI(RAPIDExecutionStateResource const&) const
 std::string RWSClient::getResourceURI(OperationModeResource const&) const
 {
   return "/rw/panel/opmode";
+}
+
+
+bool RWSClient::shouldRetry(const POCOResult result,
+                            std::set<Poco::Net::HTTPResponse::HTTPStatus> const& retry_required_statuses)
+{
+  return retry_required_statuses.count(result.httpStatus());
 }
 
 


### PR DESCRIPTION
The intent is to do a retry when we receive 403.

What happens now is:
1) We receive an update through websocket, that the rapid has stopped
2) On that event we try to restart rapid
3) When we send reset program pointer the controller responds with 403

Probably still some action is going on in controller and it doesn't allow for resetting PP. If we wait unknown amount of time, then we are able to reset it.

Since we want to do a retry on this error.

Review: @michalvi, @mkatliar 
Notify: @MathuxNY-73 