### PR TITLE
GRASP-12948 Add accepted http response statuses for http methods

### DIFF
--- a/include/abb_librws/v1_0/rws_client.h
+++ b/include/abb_librws/v1_0/rws_client.h
@@ -239,10 +239,12 @@ public:
    * \brief A method for sending a HTTP GET request and checking response status.
    *
    * \param uri for the URI (path and query).
+   * \param accepted_status accepted status values.
    *
    * \return POCOResult containing the result.
    */
-  POCOResult httpGet(const std::string& uri);
+  POCOResult httpGet(const std::string& uri,
+    std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status = {Poco::Net::HTTPResponse::HTTP_OK});
 
   /**
    * \brief A method for sending a HTTP POST request and checking response status.
@@ -261,19 +263,23 @@ public:
    *
    * \param uri for the URI (path and query).
    * \param content for the request's content.
+   * \param accepted_status accepted status values.
    *
    * \return POCOResult containing the result.
    */
-  POCOResult httpPut(const std::string& uri, const std::string& content = "");
+  POCOResult httpPut(const std::string& uri, const std::string& content = "",
+    std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status = {Poco::Net::HTTPResponse::HTTP_OK, Poco::Net::HTTPResponse::HTTP_CREATED});
 
   /**
    * \brief A method for sending a HTTP DELETE request and checking response status.
    *
    * \param uri for the URI (path and query).
+   * \param accepted_status accepted status values.
    *
    * \return POCOResult containing the result.
    */
-  POCOResult httpDelete(const std::string& uri);
+  POCOResult httpDelete(const std::string& uri,
+    std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status = {Poco::Net::HTTPResponse::HTTP_OK, Poco::Net::HTTPResponse::HTTP_NO_CONTENT});
 
 
 private:

--- a/include/abb_librws/v2_0/rws_client.h
+++ b/include/abb_librws/v2_0/rws_client.h
@@ -273,39 +273,47 @@ public:
    * \brief A method for sending a HTTP GET request and checking response status.
    *
    * \param uri for the URI (path and query).
+   * \param accepted_status accepted status values.
    *
    * \return POCOResult containing the result.
    */
-  POCOResult httpGet(const std::string& uri);
+  POCOResult httpGet(const std::string& uri,
+    std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status = {Poco::Net::HTTPResponse::HTTP_NO_CONTENT, Poco::Het::HTTPResponse::HTTP_OK});
 
   /**
    * \brief A method for sending a HTTP POST request and checking response status.
    *
    * \param uri for the URI (path and query).
    * \param content for the request's content.
+   * \param accepted_status accepted status values.
    *
    * \return POCOResult containing the result.
    */
-  POCOResult httpPost(const std::string& uri, const std::string& content = "", const std::string& content_type = "");
+  POCOResult httpPost(const std::string& uri, const std::string& content = "", const std::string& content_type = "",
+    std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status = {Poco::Net::HTTPResponse::HTTP_NO_CONTENT, Poco::Net::HTTPResponse::HTTP_OK});
 
   /**
    * \brief A method for sending a HTTP PUT request and checking response status.
    *
    * \param uri for the URI (path and query).
    * \param content for the request's content.
+   * \param accepted_status accepted status values.
    *
    * \return POCOResult containing the result.
    */
-  POCOResult httpPut(const std::string& uri, const std::string& content = "", const std::string& content_type = "");
+  POCOResult httpPut(const std::string& uri, const std::string& content = "", const std::string& content_type = ""),
+    std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status = {Poco::Net::HTTPResponse::HTTP_OK, Poco::Net::HTTPResponse::HTTP_CREATED};
 
   /**
    * \brief A method for sending a HTTP DELETE request and checking response status.
    *
    * \param uri for the URI (path and query).
+   * \param accepted_status accepted status values.
    *
    * \return POCOResult containing the result.
    */
-  POCOResult httpDelete(const std::string& uri);
+  POCOResult httpDelete(const std::string& uri,
+    std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status = {Poco::Net::HTTPResponse::HTTP_OK, Poco::Net::HTTPResponse::HTTP_NO_CONTENT});
 
 
 private:

--- a/src/v1_0/rws_client.cpp
+++ b/src/v1_0/rws_client.cpp
@@ -251,11 +251,12 @@ std::string RWSClient::generateFilePath(const FileResource& resource)
 }
 
 
-POCOResult RWSClient::httpGet(const std::string& uri)
+POCOResult RWSClient::httpGet(const std::string& uri,
+  std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status)
 {
   POCOResult const result = http_client_.httpGet(uri);
 
-  if (result.httpStatus() != HTTPResponse::HTTP_OK)
+  if (accepted_status.find(result.httpStatus()) == accepted_status.end())
     BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
       << HttpMethodErrorInfo {"GET"}
       << UriErrorInfo {uri}
@@ -287,10 +288,11 @@ POCOResult RWSClient::httpPost(const std::string& uri, const std::string& conten
 }
 
 
-POCOResult RWSClient::httpPut(const std::string& uri, const std::string& content)
+POCOResult RWSClient::httpPut(const std::string& uri, const std::string& content,
+  std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status)
 {
   POCOResult const result = http_client_.httpPut(uri, content);
-  if (result.httpStatus() != HTTPResponse::HTTP_OK && result.httpStatus() != HTTPResponse::HTTP_CREATED)
+  if (accepted_status.find(result.httpStatus()) == accepted_status.end())
     BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
       << HttpMethodErrorInfo {"PUT"}
       << UriErrorInfo {uri}
@@ -304,10 +306,11 @@ POCOResult RWSClient::httpPut(const std::string& uri, const std::string& content
 }
 
 
-POCOResult RWSClient::httpDelete(const std::string& uri)
+POCOResult RWSClient::httpDelete(const std::string& uri,
+  std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status)
 {
   POCOResult const result = http_client_.httpDelete(uri);
-  if (result.httpStatus() != HTTPResponse::HTTP_OK && result.httpStatus() != HTTPResponse::HTTP_NO_CONTENT)
+  if (accepted_status.find(result.httpStatus()) == accepted_status.end())
     BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
       << HttpMethodErrorInfo {"DELETE"}
       << HttpStatusErrorInfo {result.httpStatus()}

--- a/src/v2_0/rws_client.cpp
+++ b/src/v2_0/rws_client.cpp
@@ -304,7 +304,8 @@ std::string RWSClient::generateFilePath(const FileResource& resource)
   return Services::FILESERVICE + "/" + resource.directory + "/" + resource.filename;
 }
 
-POCOResult RWSClient::httpGet(const std::string& uri)
+POCOResult RWSClient::httpGet(const std::string& uri,
+  std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status)
 {
   POCOResult result = http_client_.httpGet(uri);
   std::list<std::chrono::milliseconds>::const_iterator it=connectionOptions_.retry_backoff.begin();
@@ -315,7 +316,7 @@ POCOResult RWSClient::httpGet(const std::string& uri)
     result = http_client_.httpGet(uri);
   }
 
-  if (result.httpStatus() != HTTPResponse::HTTP_NO_CONTENT && result.httpStatus() != HTTPResponse::HTTP_OK)
+  if (accepted_status.find(result.httpStatus()) == accepted_status.end())
     BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
       << HttpMethodErrorInfo {"GET"}
       << UriErrorInfo {uri}
@@ -328,7 +329,8 @@ POCOResult RWSClient::httpGet(const std::string& uri)
 }
 
 
-POCOResult RWSClient::httpPost(const std::string& uri, const std::string& content, const std::string& content_type)
+POCOResult RWSClient::httpPost(const std::string& uri, const std::string& content, const std::string& content_type,
+  std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status)
 {
   POCOResult result = http_client_.httpPost(uri, content, content_type);
   std::list<std::chrono::milliseconds>::const_iterator it=connectionOptions_.retry_backoff.begin();
@@ -339,7 +341,7 @@ POCOResult RWSClient::httpPost(const std::string& uri, const std::string& conten
     result = http_client_.httpPost(uri, content, content_type);
   }
 
-  if (result.httpStatus() != HTTPResponse::HTTP_NO_CONTENT && result.httpStatus() != HTTPResponse::HTTP_OK)
+  if (accepted_status.find(result.httpStatus()) == accepted_status.end())
     BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
       << HttpMethodErrorInfo {"POST"}
       << UriErrorInfo {uri}
@@ -353,7 +355,8 @@ POCOResult RWSClient::httpPost(const std::string& uri, const std::string& conten
 }
 
 
-POCOResult RWSClient::httpPut(const std::string& uri, const std::string& content, const std::string& content_type)
+POCOResult RWSClient::httpPut(const std::string& uri, const std::string& content, const std::string& content_type,
+  std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status)
 {
   POCOResult result = http_client_.httpPut(uri, content, content_type);
   std::list<std::chrono::milliseconds>::const_iterator it=connectionOptions_.retry_backoff.begin();
@@ -364,7 +367,7 @@ POCOResult RWSClient::httpPut(const std::string& uri, const std::string& content
     result = http_client_.httpPut(uri, content, content_type);
   }
 
-  if (result.httpStatus() != HTTPResponse::HTTP_OK && result.httpStatus() != HTTPResponse::HTTP_CREATED)
+  if (accepted_status.find(result.httpStatus()) == accepted_status.end())
     BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
       << HttpMethodErrorInfo {"PUT"}
       << UriErrorInfo {uri}
@@ -378,7 +381,8 @@ POCOResult RWSClient::httpPut(const std::string& uri, const std::string& content
 }
 
 
-POCOResult RWSClient::httpDelete(const std::string& uri)
+POCOResult RWSClient::httpDelete(const std::string& uri,
+  std::set<Poco::Net::HTTPResponse::HTTPStatus> const& accepted_status)
 {
   POCOResult result = http_client_.httpDelete(uri);
   std::list<std::chrono::milliseconds>::const_iterator it=connectionOptions_.retry_backoff.begin();
@@ -389,7 +393,7 @@ POCOResult RWSClient::httpDelete(const std::string& uri)
     result = http_client_.httpDelete(uri);
   }
 
-  if (result.httpStatus() != HTTPResponse::HTTP_OK && result.httpStatus() != HTTPResponse::HTTP_NO_CONTENT)
+  if (accepted_status.find(result.httpStatus()) == accepted_status.end())
     BOOST_THROW_EXCEPTION(ProtocolError {"HTTP response status not accepted"}
       << HttpMethodErrorInfo {"DELETE"}
       << HttpStatusErrorInfo {result.httpStatus()}


### PR DESCRIPTION
Changed http methods for RWSClient from having hardcoded expected http response codes to being passed by optional argument.
Existing codes are left as default.

https://nomagic.atlassian.net/browse/GRASP-12948

Review @michalvi @mkatliar

How it was tested?
On virtual robot through myke script.