### PR TITLE
GRASP-12403 Polling progress of configuration loading from robot

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ set(
     src/v1_0/rws.cpp
     src/v1_0/rws_client.cpp
     src/v1_0/rws_interface.cpp
+    src/v1_0/rws_progress.cpp
     src/v1_0/rw/rapid.cpp
     src/v1_0/rw/panel.cpp
     src/v1_0/rw/io.cpp
@@ -67,6 +68,7 @@ set(
     src/v2_0/rws.cpp
     src/v2_0/rws_client.cpp
     src/v2_0/rws_interface.cpp
+    src/v2_0/rws_progress.cpp
     src/v2_0/rw/rapid.cpp
     src/v2_0/rw/panel.cpp
     src/v2_0/rw/cfg.cpp

--- a/include/abb_librws/parsing.h
+++ b/include/abb_librws/parsing.h
@@ -7,6 +7,7 @@
 
 #include <string>
 #include <vector>
+#include <optional>
 
 
 namespace abb :: rws
@@ -132,4 +133,17 @@ namespace abb :: rws
                                                      const char start_delimiter,
                                                      const char end_delimiter,
                                                      const char separator);
+  
+  /**
+   * @brief A method to get text of first element identified by tag and containing given attribute.
+   * 
+   * @param document XML document to search.
+   * @param tag name of node.
+   * @param xml_attribute attribute the element must contain.
+   * @return text of first matched element. Empty \a std::optional if no match found.
+   */
+  std::optional<std::string> xmlNodeTextByTagAndAttribute(Poco::AutoPtr<Poco::XML::Document> p_xml_document, 
+                                          const std::string & tag, 
+                                          const XMLAttribute & xml_attribute);
+
 }

--- a/include/abb_librws/v1_0/rw/cfg.h
+++ b/include/abb_librws/v1_0/rw/cfg.h
@@ -20,9 +20,11 @@ namespace abb :: rws :: v1_0 :: rw :: cfg
      *
      * \param client RWS client
      * \param resource specifying the file's directory and name.
+     * 
+     * \return Id of progress resource.
      *
      * \throw \a RWSError if something goes wrong.
      */
-    void loadCFGFile(RWSClient& client, const FileResource& resource);
+    std::string loadCFGFile(RWSClient& client, const FileResource& resource);
 
 }

--- a/include/abb_librws/v1_0/rws_progress.h
+++ b/include/abb_librws/v1_0/rws_progress.h
@@ -1,0 +1,25 @@
+#include <abb_librws/rws.h>
+#include <abb_librws/v1_0/rws_client.h>
+
+namespace abb :: rws :: v1_0 :: progress
+{
+    /**
+     * \brief A structure for containing progress resource information.
+     */
+    struct ProgressInfo
+    {
+        std::string state;  /** \brief Progress state of resource*/
+        int code;           /** \brief Returned retcode*/
+    };
+
+    /**
+   * \brief Checks progress of provided resource.
+   * 
+   * \param id Resource id to check
+   *
+   * \return \a ProgressInfo containing the result.
+   *
+   * \throw \a RWSError if something goes wrong.
+   */
+    ProgressInfo getProgress(RWSClient& client, std::string const& id);
+}

--- a/include/abb_librws/v2_0/rw/cfg.h
+++ b/include/abb_librws/v2_0/rw/cfg.h
@@ -21,9 +21,11 @@ namespace abb :: rws :: v2_0 :: rw :: cfg
      * \param resource specifying the file's directory and name.
      * \param mastership {implicit | explicit} by default mastership is explicit
      *
+     * \return resource progress id.
+     *
      * \throw \a RWSError if something goes wrong.
      */
-    void loadCFGFile(RWSClient& client, const FileResource& resource,
+    std::string loadCFGFile(RWSClient& client, const FileResource& resource,
         Mastership const& mastership = Mastership::Explicit);
 
 }

--- a/include/abb_librws/v2_0/rws_progress.h
+++ b/include/abb_librws/v2_0/rws_progress.h
@@ -1,0 +1,25 @@
+#include <abb_librws/rws.h>
+#include <abb_librws/v2_0/rws_client.h>
+
+namespace abb :: rws :: v2_0 :: progress
+{
+    /**
+     * \brief A structure for containing progress resource information.
+     */
+    struct ProgressInfo
+    {
+        std::string state;  /** \brief Progress state of resource*/
+        int code;           /** \brief Returned retcode*/
+    };
+
+    /**
+   * \brief Checks progress of provided resource.
+   * 
+   * \param id Resource id to check
+   *
+   * \return \a ProgressInfo containing the result.
+   *
+   * \throw \a RWSError if something goes wrong.
+   */
+    ProgressInfo getProgress(RWSClient& client, std::string const& id);
+}

--- a/src/parsing.cpp
+++ b/src/parsing.cpp
@@ -282,4 +282,26 @@ namespace abb :: rws
 
     return values;
   }
+
+  std::optional<std::string> xmlNodeTextByTagAndAttribute(Poco::AutoPtr<Poco::XML::Document> p_xml_document,
+                                          const std::string & tag,
+                                          const XMLAttribute & xml_attribute)
+  {
+    if (!p_xml_document.isNull())
+    {
+      Poco::XML::NodeIterator node_iterator(p_xml_document, Poco::XML::NodeFilter::SHOW_ELEMENT);
+      Poco::XML::Node* p_node = node_iterator.nextNode();
+
+      while (p_node)
+      {
+        if (p_node->nodeName() == tag && xmlNodeHasAttribute(p_node, xml_attribute))
+        {
+          return p_node->innerText();
+        }
+
+        p_node = node_iterator.nextNode();
+      }
+    }
+    return {};
+  }
 }

--- a/src/v1_0/rw/cfg.cpp
+++ b/src/v1_0/rw/cfg.cpp
@@ -2,7 +2,7 @@
 
 namespace abb :: rws :: v1_0 :: rw :: cfg
 {
-    void loadCFGFile(RWSClient& client, const FileResource& resource)
+    std::string loadCFGFile(RWSClient& client, const FileResource& resource)
     {
         std::stringstream uri;
         uri << Resources::RW_CFG << "?action=load";
@@ -11,6 +11,24 @@ namespace abb :: rws :: v1_0 :: rw :: cfg
         std::string content =
             "filepath=" + resource.directory + "/" + resource.filename + "&action-type=replace";
 
-        client.httpPost(uri.str(), content, {Poco::Net::HTTPResponse::HTTP_NO_CONTENT});
+        POCOResult result = client.httpPost(uri.str(), content, {Poco::Net::HTTPResponse::HTTP_NO_CONTENT});
+
+        std::string progress_id;
+
+        auto const loc = std::find_if(
+            result.headerInfo().begin(), result.headerInfo().end(),
+            [] (auto it) { return it.first == "Location"; });
+
+        if(loc != result.headerInfo().end())
+        {
+            std::string const progress = "/progress/";
+            auto const start_postion = loc->second.find(progress);
+
+            if (start_postion != std::string::npos)
+                progress_id = loc->second.substr(start_postion + progress.size());
+        }
+        else
+            BOOST_THROW_EXCEPTION(ProtocolError {"CFGFile progress id not found."});
+        return progress_id;
     }
 }

--- a/src/v1_0/rws_progress.cpp
+++ b/src/v1_0/rws_progress.cpp
@@ -1,0 +1,15 @@
+#include <abb_librws/v1_0/rws_progress.h>
+
+
+namespace abb :: rws :: v1_0 :: progress
+{
+    ProgressInfo getProgress(RWSClient& client, std::string const& id)
+    {
+        std::string uri = "/progress/" + id;
+        RWSResult rws_result = parseXml(client.httpGet(uri,{Poco::Net::HTTPResponse::HTTP_OK, Poco::Net::HTTPResponse::HTTP_CREATED}).content());
+        ProgressInfo progress_info;
+        progress_info.code = std::stoi(xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","code")).value());
+        progress_info.state = xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","state")).value();
+        return progress_info;
+    }
+}

--- a/src/v2_0/rws_progress.cpp
+++ b/src/v2_0/rws_progress.cpp
@@ -1,0 +1,15 @@
+#include <abb_librws/v2_0/rws_progress.h>
+
+
+namespace abb :: rws :: v2_0 :: progress
+{
+    ProgressInfo getProgress(RWSClient& client, std::string const& id)
+    {
+        std::string uri = "/progress/" + id;
+        RWSResult rws_result = parseXml(client.httpGet(uri,{Poco::Net::HTTPResponse::HTTP_OK, Poco::Net::HTTPResponse::HTTP_CREATED}).content());
+        ProgressInfo progress_info;
+        progress_info.code = std::stoi(xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","code")).value());
+        progress_info.state = xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","state")).value();
+        return progress_info;
+    }
+}


### PR DESCRIPTION
Closed by mistake [previous PR](https://github.com/NoMagicAi/abb_librws/pull/48).

[Task](https://nomagic.atlassian.net/browse/GRASP-12403)

### Changes:
- add polling progress resource
- changed `loadCFGFile` method to return progress id
- implemented and tested `xmlNodeTextByTagAndAttribute` in `parsing.cpp`
Implemented both V1 and V2 protocol but tested only V2.

### How it was tested?
Tested using `ConfigurationUploader.cpp` [GRASP-12403](https://github.com/NoMagicAi/monomagic/blob/GRASP-12403-polling-progress-of-configuration-loading-from-robot/gripper-ros/nomagic_abb_driver/src/ConfigurationUploader.cpp) on `LAB-Hugo` robot in virtual machine using [monomagic PR 9922](https://github.com/NoMagicAi/monomagic/pull/9922).
Tested scenarios:

- Normal configuration upload resulting in normal operation
- Large file upload, so it takes time to process it resulting in "pending" progress state
- Invalid cfg file upload resulting in progress response state "ready" and an error code (code < 0)

### Additional tests:

- Checking progress of invalid resource (random progress id) results in bad request exception
- Checking error code by invalid code results in bad request exception

### To check:

1. Not sure if `getProgress` is in right place. Should it be outside `rws_client`, i.e. separate namespace and `progress.cpp`?
2. Removed Resource::PROGRESS constant from header and source, but left all other - should it be separate issue to clean them up?