### PR TITLE
GRASP-13645 Add canProcessEvent

### DIFF
--- a/include/abb_librws/rws_subscription.h
+++ b/include/abb_librws/rws_subscription.h
@@ -42,6 +42,7 @@ namespace abb :: rws
   {
     public:
         virtual std::string getURI() const = 0;
+        virtual bool canProcessEvent(Poco::XML::Element const& li_element) const = 0;
         virtual void processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const = 0;
 
         bool equals(const SubscribableResource& rhs) const
@@ -94,6 +95,11 @@ namespace abb :: rws
     SubscriptionPriority getPriority() const noexcept
     {
       return priority_;
+    }
+
+    bool canProcessEvent(Poco::XML::Element const& li_element) const
+    {
+      return resource_ptr_ -> canProcessEvent(li_element);
     }
 
     void processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const

--- a/include/abb_librws/v1_0/rw/elog.h
+++ b/include/abb_librws/v1_0/rw/elog.h
@@ -18,6 +18,8 @@ namespace abb ::rws ::v1_0 ::rw ::elog
 
         std::string getURI() const override;
 
+        bool canProcessEvent(Poco::XML::Element const &li_element) const override;
+
         void processEvent(Poco::XML::Element const &li_element, SubscriptionCallback &callback) const override;
 
     private:

--- a/include/abb_librws/v1_0/rw/io.h
+++ b/include/abb_librws/v1_0/rw/io.h
@@ -27,6 +27,8 @@ namespace abb :: rws :: v1_0 :: rw :: io
 
         std::string getURI() const override;
 
+        bool canProcessEvent(Poco::XML::Element const& li_element) const override;
+
         void processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const override;
 
 

--- a/include/abb_librws/v1_0/rw/panel.h
+++ b/include/abb_librws/v1_0/rw/panel.h
@@ -23,6 +23,8 @@ namespace abb :: rws :: v1_0 :: rw :: panel
     {
         std::string getURI() const override;
 
+        bool canProcessEvent(Poco::XML::Element const& li_element) const override;
+
         void processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const override;
     };
 
@@ -33,6 +35,8 @@ namespace abb :: rws :: v1_0 :: rw :: panel
     struct ControllerStateSubscribableResource: public SubscribableResource
     {
         std::string getURI() const override;
+
+        bool canProcessEvent(Poco::XML::Element const& li_element) const override;
 
         void processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const override;
     };

--- a/include/abb_librws/v1_0/rw/rapid.h
+++ b/include/abb_librws/v1_0/rw/rapid.h
@@ -27,6 +27,8 @@ namespace abb :: rws :: v1_0 :: rw :: rapid
 
         std::string getURI() const override;
 
+        bool canProcessEvent(Poco::XML::Element const& li_element) const override;
+
         void processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const override;
     };
 

--- a/include/abb_librws/v2_0/rw/elog.h
+++ b/include/abb_librws/v2_0/rw/elog.h
@@ -18,6 +18,8 @@ namespace abb ::rws ::v2_0 ::rw ::elog
 
         std::string getURI() const override;
 
+        bool canProcessEvent(Poco::XML::Element const &li_element) const override;
+
         void processEvent(Poco::XML::Element const &li_element, SubscriptionCallback &callback) const override;
 
     private:

--- a/include/abb_librws/v2_0/rw/io.h
+++ b/include/abb_librws/v2_0/rw/io.h
@@ -30,6 +30,8 @@ namespace abb :: rws :: v2_0 :: rw :: io
 
         std::string getURI() const override;
 
+        bool canProcessEvent(Poco::XML::Element const& li_element) const override;
+
         void processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const override;
 
     private:

--- a/include/abb_librws/v2_0/rw/panel.h
+++ b/include/abb_librws/v2_0/rw/panel.h
@@ -23,6 +23,8 @@ namespace abb :: rws :: v2_0 :: rw :: panel
     {
         std::string getURI() const override;
 
+        bool canProcessEvent(Poco::XML::Element const& li_element) const override;
+
         void processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const override;
     };
 
@@ -33,6 +35,8 @@ namespace abb :: rws :: v2_0 :: rw :: panel
     struct ControllerStateSubscribableResource: public SubscribableResource
     {
         std::string getURI() const override;
+
+        bool canProcessEvent(Poco::XML::Element const& li_element) const override;
 
         void processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const override;
     };

--- a/include/abb_librws/v2_0/rw/rapid.h
+++ b/include/abb_librws/v2_0/rw/rapid.h
@@ -27,6 +27,8 @@ namespace abb :: rws :: v2_0 :: rw :: rapid
 
         std::string getURI() const override;
 
+        bool canProcessEvent(Poco::XML::Element const& li_element) const override;
+
         void processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const override;
     };
 

--- a/src/rws_subscription.cpp
+++ b/src/rws_subscription.cpp
@@ -129,7 +129,11 @@ namespace abb :: rws
 
       // Cycle throught all subscription resources
       for (auto const& resource : resources)
-        resource.processEvent(*li_element, callback);
+      {
+        if (resource.canProcessEvent(*li_element))
+          resource.processEvent(*li_element, callback);
+      }
+        
     }
   }
 }

--- a/src/v1_0/rw/elog.cpp
+++ b/src/v1_0/rw/elog.cpp
@@ -26,11 +26,13 @@ namespace abb ::rws ::v1_0 ::rw ::elog
         return ss.str();
     }
 
+    bool ElogSubscribableResource::canProcessEvent(Poco::XML::Element const &li_element) const
+    {
+        return li_element.getAttribute("class") == "elog-message-ev";
+    }
+
     void ElogSubscribableResource::processEvent(Poco::XML::Element const &li_element, SubscriptionCallback &callback) const
     {
-        if (li_element.getAttribute("class") != "elog-message-ev")
-            return;
-
         std::string uri;
 
         auto nodes = li_element.childNodes();

--- a/src/v1_0/rw/io.cpp
+++ b/src/v1_0/rw/io.cpp
@@ -131,24 +131,25 @@ namespace abb :: rws :: v1_0 :: rw :: io
       return resource_uri;
     }
 
+    bool IOSignalSubscribableResource::canProcessEvent(Poco::XML::Element const& li_element) const
+    {
+        return li_element.getAttribute("class") == "ios-signalstate-ev";
+    }
 
     void IOSignalSubscribableResource::processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const
     {
-        if (li_element.getAttribute("class") == "ios-signalstate-ev")
+        Poco::XML::Element const * a_element = li_element.getChildElement("a");
+        if (!a_element)
+            BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: `li` element has no `a` element"});
+
+        if (a_element->getAttribute("href") == getURI())
         {
-            Poco::XML::Element const * a_element = li_element.getChildElement("a");
-            if (!a_element)
-                BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: `li` element has no `a` element"});
+            IOSignalStateEvent event;
+            event.signal = name;
+            event.value = xmlFindTextContent(&li_element, XMLAttribute {"class", "lvalue"});
+            event.resource = std::make_shared<IOSignalSubscribableResource>(event.signal);
 
-            if (a_element->getAttribute("href") == getURI())
-            {
-                IOSignalStateEvent event;
-                event.signal = name;
-                event.value = xmlFindTextContent(&li_element, XMLAttribute {"class", "lvalue"});
-                event.resource = std::make_shared<IOSignalSubscribableResource>(event.signal);
-
-                callback.processEvent(event);
-            }
+            callback.processEvent(event);
         }
     }
 }

--- a/src/v1_0/rw/panel.cpp
+++ b/src/v1_0/rw/panel.cpp
@@ -83,28 +83,34 @@ namespace abb :: rws :: v1_0 :: rw :: panel
       return "/rw/panel/opmode";
     }
 
+
+    bool OperationModeSubscribableResource::canProcessEvent(Poco::XML::Element const& li_element) const
+    {
+        return li_element.getAttribute("class") == "pnl-opmode-ev";
+    }
+
+
+    bool ControllerStateSubscribableResource::canProcessEvent(Poco::XML::Element const& li_element) const
+    {
+        return li_element.getAttribute("class") == "pnl-ctrlstate-ev";
+    }
+
     void OperationModeSubscribableResource::processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const
     {
-        if (li_element.getAttribute("class") == "pnl-opmode-ev")
-        {
-            OperationModeEvent event;
-            event.mode = rw::makeOperationMode(xmlFindTextContent(&li_element, XMLAttribute {"class", "opmode"}));
-            event.resource = std::make_shared<OperationModeSubscribableResource>();
+        OperationModeEvent event;
+        event.mode = rw::makeOperationMode(xmlFindTextContent(&li_element, XMLAttribute {"class", "opmode"}));
+        event.resource = std::make_shared<OperationModeSubscribableResource>();
 
-            callback.processEvent(event);
-        }
+        callback.processEvent(event);
     }
 
 
     void ControllerStateSubscribableResource::processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const
     {
-        if (li_element.getAttribute("class") == "pnl-ctrlstate-ev")
-        {
-            ControllerStateEvent event;
-            event.state = rw::makeControllerState(xmlFindTextContent(&li_element, XMLAttribute {"class", "ctrlstate"}));
-            event.resource = std::make_shared<ControllerStateSubscribableResource>();
+        ControllerStateEvent event;
+        event.state = rw::makeControllerState(xmlFindTextContent(&li_element, XMLAttribute {"class", "ctrlstate"}));
+        event.resource = std::make_shared<ControllerStateSubscribableResource>();
 
-            callback.processEvent(event);
-        }
+        callback.processEvent(event);
     }
 }

--- a/src/v1_0/rw/rapid.cpp
+++ b/src/v1_0/rw/rapid.cpp
@@ -246,16 +246,17 @@ namespace abb :: rws :: v1_0 :: rw :: rapid
       return "/rw/rapid/execution;ctrlexecstate";
     }
 
+    bool RAPIDExecutionStateSubscribableResource::canProcessEvent(Poco::XML::Element const& li_element) const
+    {
+        return li_element.getAttribute("class") == "rap-ctrlexecstate-ev";
+    }
 
     void RAPIDExecutionStateSubscribableResource::processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const
     {
-        if (li_element.getAttribute("class") == "rap-ctrlexecstate-ev")
-        {
-            RAPIDExecutionStateEvent event;
-            event.state = rw::makeRAPIDExecutionState(xmlFindTextContent(&li_element, XMLAttribute {"class", "ctrlexecstate"}));
-            event.resource = std::make_shared<RAPIDExecutionStateSubscribableResource>();
+        RAPIDExecutionStateEvent event;
+        event.state = rw::makeRAPIDExecutionState(xmlFindTextContent(&li_element, XMLAttribute {"class", "ctrlexecstate"}));
+        event.resource = std::make_shared<RAPIDExecutionStateSubscribableResource>();
 
-            callback.processEvent(event);
-        }
+        callback.processEvent(event);
     }
 }

--- a/src/v2_0/rw/elog.cpp
+++ b/src/v2_0/rw/elog.cpp
@@ -26,11 +26,13 @@ namespace abb ::rws ::v2_0 ::rw ::elog
         return ss.str();
     }
 
+    bool ElogSubscribableResource::canProcessEvent(Poco::XML::Element const &li_element) const
+    {
+        return li_element.getAttribute("class") == "elog-message-ev";
+    }
+
     void ElogSubscribableResource::processEvent(Poco::XML::Element const &li_element, SubscriptionCallback &callback) const
     {
-        if (li_element.getAttribute("class") != "elog-message-ev")
-            return;
-
         std::string uri;
 
         auto nodes = li_element.childNodes();

--- a/src/v2_0/rw/io.cpp
+++ b/src/v2_0/rw/io.cpp
@@ -14,23 +14,26 @@ namespace abb :: rws :: v2_0 :: rw :: io
     }
 
 
+    bool IOSignalSubscribableResource::canProcessEvent(Poco::XML::Element const& li_element) const
+    {
+        return li_element.getAttribute("class") == "ios-signalstate-ev";
+    }
+
+
     void IOSignalSubscribableResource::processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const
     {
-        if (li_element.getAttribute("class") == "ios-signalstate-ev")
+        Poco::XML::Element const * a_element = li_element.getChildElement("a");
+        if (!a_element)
+            BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: `li` element has no `a` element"});
+
+        if (a_element->getAttribute("href") == getURI())
         {
-            Poco::XML::Element const * a_element = li_element.getChildElement("a");
-            if (!a_element)
-                BOOST_THROW_EXCEPTION(ProtocolError {"Cannot parse RWS event message: `li` element has no `a` element"});
+            IOSignalStateEvent event;
+            event.signal = name;
+            event.value = xmlFindTextContent(&li_element, XMLAttribute {"class", "lvalue"});
+            event.resource = std::make_shared<IOSignalSubscribableResource>(event.signal);
 
-            if (a_element->getAttribute("href") == getURI())
-            {
-                IOSignalStateEvent event;
-                event.signal = name;
-                event.value = xmlFindTextContent(&li_element, XMLAttribute {"class", "lvalue"});
-                event.resource = std::make_shared<IOSignalSubscribableResource>(event.signal);
-
-                callback.processEvent(event);
-            }
+            callback.processEvent(event);
         }
     }
 }

--- a/src/v2_0/rw/panel.cpp
+++ b/src/v2_0/rw/panel.cpp
@@ -85,28 +85,34 @@ namespace abb :: rws :: v2_0 :: rw :: panel
     }
 
 
+    bool ControllerStateSubscribableResource::canProcessEvent(Poco::XML::Element const& li_element) const
+    {
+        return li_element.getAttribute("class") == "pnl-ctrlstate-ev";
+    }
+
+
+    bool OperationModeSubscribableResource::canProcessEvent(Poco::XML::Element const& li_element) const
+    {
+        return li_element.getAttribute("class") == "pnl-opmode-ev";
+    }
+
+
     void ControllerStateSubscribableResource::processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const
     {
-        if (li_element.getAttribute("class") == "pnl-ctrlstate-ev")
-        {
-            ControllerStateEvent event;
-            event.state = rw::makeControllerState(xmlFindTextContent(&li_element, XMLAttribute {"class", "ctrlstate"}));
-            event.resource = std::make_shared<ControllerStateSubscribableResource>();
+        ControllerStateEvent event;
+        event.state = rw::makeControllerState(xmlFindTextContent(&li_element, XMLAttribute {"class", "ctrlstate"}));
+        event.resource = std::make_shared<ControllerStateSubscribableResource>();
 
-            callback.processEvent(event);
-        }
+        callback.processEvent(event);
     }
 
 
     void OperationModeSubscribableResource::processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const
     {
-        if (li_element.getAttribute("class") == "pnl-opmode-ev")
-        {
-            OperationModeEvent event;
-            event.mode = rw::makeOperationMode(xmlFindTextContent(&li_element, XMLAttribute {"class", "opmode"}));
-            event.resource = std::make_shared<OperationModeSubscribableResource>();
+        OperationModeEvent event;
+        event.mode = rw::makeOperationMode(xmlFindTextContent(&li_element, XMLAttribute {"class", "opmode"}));
+        event.resource = std::make_shared<OperationModeSubscribableResource>();
 
-            callback.processEvent(event);
-        }
+        callback.processEvent(event);
     }
 }

--- a/src/v2_0/rw/rapid.cpp
+++ b/src/v2_0/rw/rapid.cpp
@@ -264,16 +264,17 @@ namespace abb :: rws :: v2_0 :: rw :: rapid
       return "/rw/rapid/execution;ctrlexecstate";
     }
 
+    bool RAPIDExecutionStateSubscribableResource::canProcessEvent(Poco::XML::Element const& li_element) const
+    {
+        return li_element.getAttribute("class") == "rap-ctrlexecstate-ev";
+    }
 
     void RAPIDExecutionStateSubscribableResource::processEvent(Poco::XML::Element const& li_element, SubscriptionCallback& callback) const
     {
-        if (li_element.getAttribute("class") == "rap-ctrlexecstate-ev")
-        {
-            RAPIDExecutionStateEvent event;
-            event.state = rw::makeRAPIDExecutionState(xmlFindTextContent(&li_element, XMLAttribute {"class", "ctrlexecstate"}));
-            event.resource = std::make_shared<RAPIDExecutionStateSubscribableResource>();
+        RAPIDExecutionStateEvent event;
+        event.state = rw::makeRAPIDExecutionState(xmlFindTextContent(&li_element, XMLAttribute {"class", "ctrlexecstate"}));
+        event.resource = std::make_shared<RAPIDExecutionStateSubscribableResource>();
 
-            callback.processEvent(event);
-        }
+        callback.processEvent(event);
     }
 }


### PR DESCRIPTION
[Jira task](https://nomagic.atlassian.net/browse/GRASP-13645)

In `rws_subscription.cpp` in `processAllEvents` metod events are passed to every resource for processing:
```
// Cycle through all subscription resources
   for (auto const& resource : resources)
      resource.processEvent(*li_element, callback);
```
I propose to add `canProcessEvent` method to `SubscribableResource` that requires active checking of the type of event:
```
for (auto const& resource : resources)
{
   if (resource.canProcessEvent(*li_element))
      resource.processEvent(*li_element, callback);
}
```