### PR TITLE
Add getRetcodes, separate common retcode code

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,7 @@ set(
     src/common/rw/panel.cpp
     src/common/rw/ctrl.cpp
     src/common/rw/elog.cpp
+    src/common/rw/retcode.cpp
 
     src/v1_0/rws.cpp
     src/v1_0/rws_client.cpp

--- a/include/abb_librws/common/rw/retcode.h
+++ b/include/abb_librws/common/rw/retcode.h
@@ -17,3 +17,5 @@ namespace abb::rws::rw::retcode
 
     std::string to_string(RetcodeInfo const& retcode);
 }
+
+std::ostream& operator<<(std::ostream& os, abb::rws::rw::retcode::RetcodeInfo const& info);

--- a/include/abb_librws/common/rw/retcode.h
+++ b/include/abb_librws/common/rw/retcode.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <string>
+
+namespace abb::rws::rw::retcode
+{
+    /**
+     * \brief A structure for containing response of recode resource.
+     */
+    struct RetcodeInfo
+    {
+        int code;                /** \brief The error code or success code as number */
+        std::string name;        /** \brief The name of error code or success code */
+        std::string severity;    /** \brief Success, Warning or Error */
+        std::string description; /** \brief Short description of the error code */
+    };
+
+    std::string to_string(RetcodeInfo const& retcode);
+}

--- a/include/abb_librws/rws_error.h
+++ b/include/abb_librws/rws_error.h
@@ -113,4 +113,9 @@ namespace abb :: rws
    * \brief Error info containing an URI.
    */
   using UriErrorInfo = boost::error_info<struct UriErrorInfoTag, std::string>;
+
+  /**
+   * \brief Error info containing return code.
+   */
+  using RetcodeErrorInfo = boost::error_info<struct RetcodeErrorInfoTag, int>;
 }

--- a/include/abb_librws/v1_0/rw/retcode.h
+++ b/include/abb_librws/v1_0/rw/retcode.h
@@ -1,40 +1,40 @@
+#pragma once
+
 #include <abb_librws/rws.h>
+#include <abb_librws/common/rw/retcode.h>
 #include <abb_librws/v1_0/rws_client.h>
 
 #include <string>
+#include <map>
 
-
-namespace abb :: rws :: v1_0 :: rw
+namespace abb::rws::v1_0::rw::retcode
 {
-    using namespace rws::rw;
-}
-
-
-namespace abb :: rws :: v1_0 :: rw :: retcode
-{
-    /**
-     * \brief A structure for containing response of recode resource.
-     */
-    struct RetcodeInfo
-    {
-        int code;                   /** \brief The error code or success code as number */
-        std::string name;           /** \brief The name of error code or success code */
-        std::string severity;       /** \brief Success, Warning or Error */
-        std::string description;    /** \brief Short description of the error code */
-    };
-
+    using namespace abb::rws::rw::retcode;
 
     /**
-     * \brief A function for checking description of diagnostic code.
+     * \brief Get description of diagnostic code.
      *
      * https://developercenter.robotstudio.com/api/rwsApi/rwretcode_get_return_codes.html
      *
      * \param client RWS client
      * \param code code to be checked.
-     * 
+     *
      * \return \a RetcodeInfo containing the result.
      *
      * \throw \a RWSError if something goes wrong.
      */
-    RetcodeInfo getRetcodeInfo(RWSClient& client, int code);
+    RetcodeInfo getRetcodeInfo(RWSClient &client, int code);
+
+    /**
+     * @brief Get descriptions of all diagnostic codes.
+     *
+     * https://developercenter.robotstudio.com/api/rwsApi/rwretcode_get_return_codes.html
+     *
+     * \param client RWS client
+     *
+     * \return \a map<int,RetcodeInfo> with error code as key and RetcodeInfo structure as value.
+     *
+     * \throw \a RWSError if something goes wrong.
+     */
+    std::map<int, RetcodeInfo> getRetcodes(RWSClient &client);
 }

--- a/include/abb_librws/v2_0/rw/retcode.h
+++ b/include/abb_librws/v2_0/rw/retcode.h
@@ -1,40 +1,40 @@
+#pragma once
+
 #include <abb_librws/rws.h>
+#include <abb_librws/common/rw/retcode.h>
 #include <abb_librws/v2_0/rws_client.h>
 
 #include <string>
+#include <map>
 
-
-namespace abb :: rws :: v2_0 :: rw
+namespace abb::rws::v2_0::rw::retcode
 {
-    using namespace rws::rw;
-}
-
-
-namespace abb :: rws :: v2_0 :: rw :: retcode
-{
-    /**
-     * \brief A structure for containing response of recode resource.
-     */
-    struct RetcodeInfo
-    {
-        int code;                   /** \brief The error code or success code as number */
-        std::string name;           /** \brief The name of error code or success code */
-        std::string severity;       /** \brief Success, Warning or Error */
-        std::string description;    /** \brief Short description of the error code */
-    };
-
+    using namespace abb::rws::rw::retcode;
 
     /**
-     * \brief A function for checking description of diagnostic code.
+     * \brief Get description of diagnostic code.
      *
      * https://developercenter.robotstudio.com/api/rwsApi/rwretcode_get_return_codes.html
      *
      * \param client RWS client
      * \param code code to be checked.
-     * 
+     *
      * \return \a RetcodeInfo containing the result.
      *
      * \throw \a RWSError if something goes wrong.
      */
-    RetcodeInfo getRetcodeInfo(RWSClient& client, int code);
+    RetcodeInfo getRetcodeInfo(RWSClient &client, int code);
+
+    /**
+     * @brief Get descriptions of all diagnostic codes.
+     *
+     * https://developercenter.robotstudio.com/api/rwsApi/rwretcode_get_return_codes.html
+     *
+     * \param client RWS client
+     *
+     * \return \a map<int,RetcodeInfo> with error code as key and RetcodeInfo structure as value.
+     *
+     * \throw \a RWSError if something goes wrong.
+     */
+    std::map<int, RetcodeInfo> getRetcodes(RWSClient &client);
 }

--- a/src/common/rw/retcode.cpp
+++ b/src/common/rw/retcode.cpp
@@ -11,3 +11,9 @@ namespace abb::rws::rw::retcode
         return ss.str(); 
     }
 }
+
+std::ostream& operator<<(std::ostream& os, abb::rws::rw::retcode::RetcodeInfo const& info)
+{
+    os << info.severity << " " << info.code << " " << info.name << ": " << info.description;
+    return os;
+}

--- a/src/common/rw/retcode.cpp
+++ b/src/common/rw/retcode.cpp
@@ -1,0 +1,13 @@
+#include <abb_librws/common/rw/retcode.h>
+
+#include <sstream>
+
+namespace abb::rws::rw::retcode
+{
+    std::string to_string(RetcodeInfo const& info)
+    {
+        std::stringstream ss;
+        ss << info.severity << " " << info.code << " " << info.name << ": " << info.description;
+        return ss.str(); 
+    }
+}

--- a/src/v1_0/rw/retcode.cpp
+++ b/src/v1_0/rw/retcode.cpp
@@ -1,18 +1,40 @@
 #include <abb_librws/v1_0/rw/retcode.h>
 
 
-namespace abb :: rws :: v1_0 :: rw :: retcode
+namespace abb::rws::v1_0::rw::retcode
 {
+    RetcodeInfo parseErrorDescriptionXml(Poco::XML::Node* node)
+    {
+        RetcodeInfo retcode_info;
+        retcode_info.code = std::stoi(xmlFindTextContent(node, abb::rws::XMLAttribute("class","code")));
+        retcode_info.name = xmlFindTextContent(node, abb::rws::XMLAttribute("class","name"));
+        retcode_info.severity = xmlFindTextContent(node, abb::rws::XMLAttribute("class","severity"));
+        retcode_info.description = xmlFindTextContent(node, abb::rws::XMLAttribute("class","description"));
+        return retcode_info;
+    }
+
     RetcodeInfo getRetcodeInfo(RWSClient& client, int code)
     {
         std::stringstream uri;
         uri << "/rw/retcode?code=" << code;
-        RWSResult const& rws_result = parseXml(client.httpGet(uri.str()).content());
-        RetcodeInfo retcode_info;
-        retcode_info.code = std::stoi(xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","code")).value());
-        retcode_info.name = xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","name")).value();
-        retcode_info.severity = xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","severity")).value();
-        retcode_info.description = xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","description")).value();
-        return retcode_info;
+        POCOResult poco_result = client.httpGet(uri.str());
+        RWSResult const& rws_result = parseXml(poco_result.content());
+        std::vector<Poco::XML::Node*> nodes = xmlFindNodes(rws_result, XMLAttribute("class", "err-desc"));
+        return parseErrorDescriptionXml(nodes[0]);
+    }
+
+    std::map<int, RetcodeInfo> getRetcodes(RWSClient& client)
+    {
+        std::string uri = "/rw/retcode";
+        POCOResult poco_result = client.httpGet(uri);
+        RWSResult const& rws_result = parseXml(poco_result.content());
+        std::vector<Poco::XML::Node*> nodes = xmlFindNodes(rws_result, XMLAttribute("class", "err-desc-li"));
+        std::map<int,RetcodeInfo> retcodes;
+        for (auto node : nodes)
+        {
+            RetcodeInfo info = parseErrorDescriptionXml(node);
+            retcodes[info.code] = info;
+        }
+        return retcodes;
     }
 }

--- a/src/v1_0/rw/retcode.cpp
+++ b/src/v1_0/rw/retcode.cpp
@@ -20,6 +20,12 @@ namespace abb::rws::v1_0::rw::retcode
         POCOResult poco_result = client.httpGet(uri.str());
         RWSResult const& rws_result = parseXml(poco_result.content());
         std::vector<Poco::XML::Node*> nodes = xmlFindNodes(rws_result, XMLAttribute("class", "err-desc"));
+        if (nodes.empty())
+        {
+            using content_info = boost::error_info<struct XmlContent, std::string>;
+            BOOST_THROW_EXCEPTION(boost::enable_error_info(std::runtime_error("Unable to find error description: "))
+                                    << content_info {poco_result.content()});
+        }
         return parseErrorDescriptionXml(nodes[0]);
     }
 

--- a/src/v1_0/rws_client.cpp
+++ b/src/v1_0/rws_client.cpp
@@ -41,6 +41,7 @@
 
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/DOM/NodeList.h>
+#include <Poco/DOM/DOMException.h>
 
 #include <sstream>
 #include <stdexcept>
@@ -263,7 +264,10 @@ std::optional<int> tryParseRetcode(std::string const& content) noexcept
     std::string code_str = xmlFindTextContent(xml, XMLAttribute{"class", "code"});
     if (!code_str.empty())
         result = std::stoi(code_str);
-  } catch (...) {}
+  } 
+  catch (Poco::XML::XMLException const&) {}
+  catch (std::invalid_argument const&) {}
+  catch (std::out_of_range const&) {}
   return result;
 }
 

--- a/src/v2_0/rw/retcode.cpp
+++ b/src/v2_0/rw/retcode.cpp
@@ -1,18 +1,40 @@
 #include <abb_librws/v2_0/rw/retcode.h>
 
 
-namespace abb :: rws :: v2_0 :: rw :: retcode
+namespace abb::rws::v2_0::rw::retcode
 {
+    RetcodeInfo parseErrorDescriptionXml(Poco::XML::Node* node)
+    {
+        RetcodeInfo retcode_info;
+        retcode_info.code = std::stoi(xmlFindTextContent(node, abb::rws::XMLAttribute("class","code")));
+        retcode_info.name = xmlFindTextContent(node, abb::rws::XMLAttribute("class","name"));
+        retcode_info.severity = xmlFindTextContent(node, abb::rws::XMLAttribute("class","severity"));
+        retcode_info.description = xmlFindTextContent(node, abb::rws::XMLAttribute("class","description"));
+        return retcode_info;
+    }
+
     RetcodeInfo getRetcodeInfo(RWSClient& client, int code)
     {
         std::stringstream uri;
         uri << "/rw/retcode?code=" << code;
-        RWSResult const& rws_result = parseXml(client.httpGet(uri.str()).content());
-        RetcodeInfo retcode_info;
-        retcode_info.code = std::stoi(xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","code")).value());
-        retcode_info.name = xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","name")).value();
-        retcode_info.severity = xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","severity")).value();
-        retcode_info.description = xmlNodeTextByTagAndAttribute(rws_result, "span", abb::rws::XMLAttribute("class","description")).value();
-        return retcode_info;
+        POCOResult poco_result = client.httpGet(uri.str());
+        RWSResult const& rws_result = parseXml(poco_result.content());
+        std::vector<Poco::XML::Node*> nodes = xmlFindNodes(rws_result, XMLAttribute("class", "err-desc"));
+        return parseErrorDescriptionXml(nodes[0]);
+    }
+
+    std::map<int, RetcodeInfo> getRetcodes(RWSClient& client)
+    {
+        std::string uri = "/rw/retcode";
+        POCOResult poco_result = client.httpGet(uri);
+        RWSResult const& rws_result = parseXml(poco_result.content());
+        std::vector<Poco::XML::Node*> nodes = xmlFindNodes(rws_result, XMLAttribute("class", "err-desc-li"));
+        std::map<int,RetcodeInfo> retcodes;
+        for (auto node : nodes)
+        {
+            RetcodeInfo info = parseErrorDescriptionXml(node);
+            retcodes[info.code] = info;
+        }
+        return retcodes;
     }
 }

--- a/src/v2_0/rw/retcode.cpp
+++ b/src/v2_0/rw/retcode.cpp
@@ -20,6 +20,12 @@ namespace abb::rws::v2_0::rw::retcode
         POCOResult poco_result = client.httpGet(uri.str());
         RWSResult const& rws_result = parseXml(poco_result.content());
         std::vector<Poco::XML::Node*> nodes = xmlFindNodes(rws_result, XMLAttribute("class", "err-desc"));
+        if (nodes.empty())
+        {
+            using content_info = boost::error_info<struct XmlContent, std::string>;
+            BOOST_THROW_EXCEPTION(boost::enable_error_info(std::runtime_error("Unable to find error description: "))
+                                    << content_info {poco_result.content()});
+        }
         return parseErrorDescriptionXml(nodes[0]);
     }
 

--- a/src/v2_0/rws_client.cpp
+++ b/src/v2_0/rws_client.cpp
@@ -41,6 +41,7 @@
 
 #include <Poco/Net/HTTPRequest.h>
 #include <Poco/DOM/NodeList.h>
+#include <Poco/XML/XMLException.h>
 
 #include <boost/log/trivial.hpp>
 
@@ -314,7 +315,10 @@ std::optional<int> tryParseRetcode(std::string const& content) noexcept
     std::string code_str = xmlFindTextContent(xml, XMLAttribute{"class", "code"});
     if (!code_str.empty())
         result = std::stoi(code_str);
-  } catch (...) {}
+  } 
+  catch (Poco::XML::XMLException const&) {}
+  catch (std::invalid_argument const&) {}
+  catch (std::out_of_range const&) {}
   return result;
 }
 

--- a/src/v2_0/rws_client.cpp
+++ b/src/v2_0/rws_client.cpp
@@ -304,22 +304,18 @@ std::string RWSClient::generateFilePath(const FileResource& resource)
   return Services::FILESERVICE + "/" + resource.directory + "/" + resource.filename;
 }
 
-// Try finding xml tag with class="code" containing retcode.
-std::optional<int> tryParseRetcode(Poco::AutoPtr<Poco::XML::Document> const& xml)
+// Try finding xml tag with class="code" attribute containing retcode. Does not throw.
+std::optional<int> tryParseRetcode(std::string const& content) noexcept
 {
-  std::string code_str = xmlFindTextContent(xml, XMLAttribute{"class", "code"});
+  std::optional<int> result;
   try
   {
-    return std::stoi(code_str);
-  }
-  catch (std::invalid_argument)
-  {
-    return {};
-  }
-  catch (std::out_of_range)
-  {
-    return {};
-  }
+    auto xml = parseXml(content);
+    std::string code_str = xmlFindTextContent(xml, XMLAttribute{"class", "code"});
+    if (!code_str.empty())
+        result = std::stoi(code_str);
+  } catch (...) {}
+  return result;
 }
 
 POCOResult RWSClient::httpGet(const std::string& uri,
@@ -342,7 +338,7 @@ POCOResult RWSClient::httpGet(const std::string& uri,
       << HttpStatusErrorInfo {result.httpStatus()}
       << HttpResponseContentErrorInfo {result.content()}
       << HttpReasonErrorInfo {result.reason()};
-    if (auto retcode = tryParseRetcode(parseXml(result.content())))
+    if (auto retcode = tryParseRetcode(result.content()))
       exception << RetcodeErrorInfo {retcode.value()};
     BOOST_THROW_EXCEPTION(exception);
   }
@@ -372,7 +368,7 @@ POCOResult RWSClient::httpPost(const std::string& uri, const std::string& conten
       << HttpStatusErrorInfo {result.httpStatus()}
       << HttpResponseContentErrorInfo {result.content()}
       << HttpReasonErrorInfo {result.reason()};
-    if (auto retcode = tryParseRetcode(parseXml(result.content())))
+    if (auto retcode = tryParseRetcode(result.content()))
       exception << RetcodeErrorInfo {retcode.value()};
     BOOST_THROW_EXCEPTION(exception);
   }
@@ -400,7 +396,7 @@ POCOResult RWSClient::httpPut(const std::string& uri, const std::string& content
       << HttpStatusErrorInfo {result.httpStatus()}
       << HttpResponseContentErrorInfo {result.content()}
       << HttpReasonErrorInfo {result.reason()};
-    if (auto retcode = tryParseRetcode(parseXml(result.content())))
+    if (auto retcode = tryParseRetcode(result.content()))
       exception << RetcodeErrorInfo {retcode.value()};
     BOOST_THROW_EXCEPTION(exception);
   }
@@ -429,7 +425,7 @@ POCOResult RWSClient::httpDelete(const std::string& uri,
       << HttpStatusErrorInfo {result.httpStatus()}
       << HttpResponseContentErrorInfo {result.content()}
       << HttpReasonErrorInfo {result.reason()};
-    if (auto retcode = tryParseRetcode(parseXml(result.content())))
+    if (auto retcode = tryParseRetcode(result.content()))
       exception << RetcodeErrorInfo {retcode.value()};
     BOOST_THROW_EXCEPTION(exception);
   }


### PR DESCRIPTION
### Changes
- Add `getRetcodes` function
- Separate `RetcodeInfo` into common namespace
- Add `to_string` for `RetcodeInfo` struct

### Review

_Review_: @mkatliar @krzyfre   
_Notify_: @krzysztof-gomulski 