### PR TITLE
GRASP-13849 errors when switching motors off

### DIFF
--- a/include/abb_librws/rws_subscription.h
+++ b/include/abb_librws/rws_subscription.h
@@ -101,6 +101,11 @@ namespace abb :: rws
       resource_ptr_ -> processEvent(li_element, callback);
     }
 
+    bool operator == ( SubscriptionResource const& other ) const noexcept
+    {
+      return getURI() == other.getURI() && getPriority() == other.getPriority();
+    }
+
   private:
 
     std::shared_ptr<SubscribableResource> resource_ptr_;

--- a/src/v1_0/rws_client.cpp
+++ b/src/v1_0/rws_client.cpp
@@ -196,7 +196,8 @@ void RWSClient::deleteFile(const FileResource& resource)
 void RWSClient::logout()
 {
   std::string uri = Resources::LOGOUT;
-  httpGet(uri, {Poco::Net::HTTPResponse::HTTP_NO_CONTENT});
+  //ABB controller sometimes gives HTTP_OK in response, although according to the documentation it should be HTTP_NO_CONTENT
+  httpGet(uri, {Poco::Net::HTTPResponse::HTTP_OK, Poco::Net::HTTPResponse::HTTP_NO_CONTENT});
 }
 
 

--- a/src/v1_0/subscription.cpp
+++ b/src/v1_0/subscription.cpp
@@ -106,6 +106,11 @@ namespace abb :: rws :: v1_0 :: subscription
 
   void SubscriptionGroup::updateResources(SubscriptionResources const& res)
   {
+    //We skip updating resources to the controller if there are no changes
+    if (res == resources_)
+    {
+      return;
+    }
     POCOResult result = client_.httpPut(Services::SUBSCRIPTION + "/" + subscription_group_id_, resourcesString(client_, res));
     resources_ = res;
 

--- a/src/v2_0/subscription.cpp
+++ b/src/v2_0/subscription.cpp
@@ -106,6 +106,11 @@ namespace abb :: rws :: v2_0 :: subscription
 
   void SubscriptionGroup::updateResources(SubscriptionResources const& res)
   {
+    //We skip updating resources to the controller if there are no changes
+    if (res == resources_)
+    {
+      return;
+    }
     client_.httpPut(Services::SUBSCRIPTION + "/" + subscription_group_id_, resourcesString(client_, res), "application/x-www-form-urlencoded;v=2.0");
     resources_ = res;
   }


### PR DESCRIPTION
[Jira task](https://nomagic.atlassian.net/browse/GRASP-13849)

Tested together with [this PR](https://github.com/NoMagicAi/monomagic/pull/10796)

### How was the change tested?
rosrun nomagic_abb_driver nomagic_abb_driver-integration-test

```
[----------] Global test environment tear-down
[==========] 66 tests from 7 test suites ran. (179321 ms total)
[  PASSED  ] 66 tests.
```

### Review

_Review_: @mkatliar, @krzysztof-gomulski 
_Notify_: @_person2_