### PR TITLE
fix bug with interval type

### DIFF
--- a/src/rws_subscription.cpp
+++ b/src/rws_subscription.cpp
@@ -73,7 +73,7 @@ namespace abb :: rws
 
       {
         std::lock_guard lock{socketMutex_};
-        webSocket_.setReceiveTimeout(WEBSOCKET_UPDATE_INTERVAL);
+        webSocket_.setReceiveTimeout(Poco::Timespan(WEBSOCKET_UPDATE_INTERVAL.count()));
         flags = 0;
 
         try


### PR DESCRIPTION
Fixing bug appearing during compilation:

`mkdir build`
`cd build`
`cmake ..`
`cmake --build .`
